### PR TITLE
Fixes for 0.10.1.11 that marq24 caused by overwriting estimated distance

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -421,7 +421,10 @@ public class GraphHopper implements GraphHopperAPI {
      * This method specifies if the returned path should be simplified or not, via douglas-peucker
      * or similar algorithm.
      */
+    //ORS-GH MOD START
+    //private GraphHopper setSimplifyResponse(boolean doSimplify) {
     public GraphHopper setSimplifyResponse(boolean doSimplify) {
+    //ORS-GH MOD END
         this.simplifyResponse = doSimplify;
         return this;
     }


### PR DESCRIPTION
when I had initially introduced the traffic light & crossing count I also modified the code that is calculating the estimated_distance & center (instead of using just first & last lat/lon the code goes though the complete way).

This change caused a test in ors branch to fail... With this PR this change will be reverted - estimated_distance will be calculated as in the original gh branch - and the exact_distance & center have been added additionally

Also marked the ORS-GH Change (changed declaration in GraphHopper.class)