### PR TITLE
Changes required by GIScience/openrouteservice#750

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/EdgeElevationInterpolator.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/EdgeElevationInterpolator.java
@@ -157,7 +157,9 @@ public class EdgeElevationInterpolator {
                 }
                 if (count > 2)
                     edge.setWayGeometry(pointList.shallowCopy(1, count - 1, false));
-                edge.setDistance(pointList.calcDistance(Helper.DIST_3D));
+                // ORS-GH MOD START
+                //edge.setDistance(pointList.calcDistance(Helper.DIST_3D));
+                // ORS-GH MOD END
             }
         }
     }


### PR DESCRIPTION
Disables distance recalculation of interpolated edges. The reason for this change is that the edge distance computation in ORS does not consider elevation data anyway, so the edge length is not expected to change. A proper implementation allowing for setting a method for doing the distance calculation would require a lot of changes and and is beyond our current scope.