### PR TITLE
Check for conditional access and speed encoders

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/DefaultSpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/DefaultSpeedCalculator.java
@@ -1,0 +1,21 @@
+package com.graphhopper.routing.util;
+
+import com.graphhopper.routing.profiles.DecimalEncodedValue;
+import com.graphhopper.util.EdgeIteratorState;
+
+/**
+ * Retrieve default speed
+ *
+ * @author Andrzej Oles
+ */
+public class DefaultSpeedCalculator implements SpeedCalculator{
+    protected final DecimalEncodedValue avSpeedEnc;
+
+    public DefaultSpeedCalculator(FlagEncoder encoder) {
+        avSpeedEnc = encoder.getAverageSpeedEnc();
+    }
+
+    public double getSpeed(EdgeIteratorState edge, boolean reverse, long time) {
+        return reverse ? edge.getReverse(avSpeedEnc) : edge.get(avSpeedEnc);
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/weighting/TimeDependentFastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/TimeDependentFastestWeighting.java
@@ -42,13 +42,15 @@ public class TimeDependentFastestWeighting extends AbstractWeighting {
 
     private SpeedCalculator speedCalculator;
 
+    public TimeDependentFastestWeighting(FlagEncoder encoder, PMap map) {
+        this(encoder, map, new DefaultSpeedCalculator(encoder));
+    }
 
-    public TimeDependentFastestWeighting(FlagEncoder encoder, PMap map, GraphHopperStorage graph) {
+    public TimeDependentFastestWeighting(FlagEncoder encoder, PMap map, SpeedCalculator speedCalculator) {
         super(encoder);
         headingPenalty = map.getDouble(Routing.HEADING_PENALTY, Routing.DEFAULT_HEADING_PENALTY);
         maxSpeed = encoder.getMaxSpeed() / SPEED_CONV;
-
-        this.speedCalculator = new ConditionalSpeedCalculator(graph, encoder);
+        this.speedCalculator = speedCalculator;
     }
 
     @Override


### PR DESCRIPTION
Decouple `TimeDependentFastestWeighting` from `ConditionalSpeedCalculator` in order to be able to use it with flag encoders which don't store OSM conditional speeds.