### PR TITLE
Resolve default access of conditional edges at graph build time

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/ConditionalInspector.java
+++ b/core/src/main/java/com/graphhopper/reader/ConditionalInspector.java
@@ -20,6 +20,8 @@ package com.graphhopper.reader;
 /**
  * @author Andrzej Oles
  */
-public interface ConditionalSpeedInspector extends ConditionalInspector{
-    boolean hasConditionalSpeed(ReaderWay way);
+public interface ConditionalInspector {
+    boolean hasLazyEvaluatedConditions();
+
+    String getTagValue();
 }

--- a/core/src/main/java/com/graphhopper/reader/ConditionalTagInspector.java
+++ b/core/src/main/java/com/graphhopper/reader/ConditionalTagInspector.java
@@ -20,12 +20,8 @@ package com.graphhopper.reader;
 /**
  * @author Peter Karich
  */
-public interface ConditionalTagInspector {
+public interface ConditionalTagInspector extends ConditionalInspector {
     boolean isRestrictedWayConditionallyPermitted(ReaderWay way);
 
     boolean isPermittedWayConditionallyRestricted(ReaderWay way);
-
-    boolean isConditionLazyEvaluated();
-
-    String getTagValue();
 }

--- a/core/src/main/java/com/graphhopper/reader/osm/conditional/ConditionalOSMSpeedInspector.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/conditional/ConditionalOSMSpeedInspector.java
@@ -39,6 +39,7 @@ public class ConditionalOSMSpeedInspector implements ConditionalSpeedInspector {
     private boolean enabledLogs = true;
 
     private String val;
+    private boolean isLazyEvaluated;
 
     @Override
     public String getTagValue() {
@@ -71,10 +72,11 @@ public class ConditionalOSMSpeedInspector implements ConditionalSpeedInspector {
             if (val == null || val.isEmpty())
                 continue;
             try {
-                if (parser.checkCondition(val)) {
-                    val = parser.getRestrictions();
+                ConditionalParser.Result result = parser.checkCondition(val);
+                isLazyEvaluated = result.isLazyEvaluated();
+                val = result.getRestrictions();
+                if (result.isCheckPassed() || isLazyEvaluated)
                     return true;
-                }
             } catch (Exception e) {
                 if (enabledLogs) {
                     logger.warn("for way " + way.getId() + " could not parse the conditional value '" + val + "' of tag '" + tagToCheck + "'. Exception:" + e.getMessage());
@@ -85,8 +87,8 @@ public class ConditionalOSMSpeedInspector implements ConditionalSpeedInspector {
     }
 
     @Override
-    public boolean isConditionLazyEvaluated() {
-        return parser.hasUnevaluatedRestrictions();
+    public boolean hasLazyEvaluatedConditions() {
+        return isLazyEvaluated;
     }
 
 }

--- a/core/src/main/java/com/graphhopper/reader/osm/conditional/ConditionalOSMTagInspector.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/conditional/ConditionalOSMTagInspector.java
@@ -80,12 +80,11 @@ public class ConditionalOSMTagInspector implements ConditionalTagInspector {
     }
 
     @Override
-    public boolean isConditionLazyEvaluated() {
+    public boolean hasLazyEvaluatedConditions() {
         return isLazyEvaluated;
     }
 
     protected boolean applies(ReaderWay way, ConditionalParser parser) {
-
         isLazyEvaluated = false;
         for (int index = 0; index < tagsToCheck.size(); index++) {
             String tagToCheck = tagsToCheck.get(index);
@@ -93,12 +92,12 @@ public class ConditionalOSMTagInspector implements ConditionalTagInspector {
             if (val == null || val.isEmpty())
                 continue;
             try {
-                if (parser.checkCondition(val)) {
-                    if (parser.hasUnevaluatedRestrictions())
-                        isLazyEvaluated = true;
-                    val = parser.getRestrictions();
-                    return true;
-                }
+                ConditionalParser.Result result = parser.checkCondition(val);
+                isLazyEvaluated = result.isLazyEvaluated();
+                val = result.getRestrictions();
+                // allow the check result to be false but still have unevaluated conditions
+                if (result.isCheckPassed() || isLazyEvaluated)
+                    return result.isCheckPassed();
             } catch (Exception e) {
                 if (enabledLogs) {
                     // log only if no date ala 21:00 as currently date and numbers do not support time precise restrictions

--- a/core/src/main/java/com/graphhopper/routing/TDAStar.java
+++ b/core/src/main/java/com/graphhopper/routing/TDAStar.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.routing;
 
+import com.graphhopper.routing.util.ConditionalAccessEdgeFilter;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
@@ -35,6 +36,10 @@ public class TDAStar extends AStar {
 
     public TDAStar(Graph graph, Weighting weighting, TraversalMode tMode) {
         super(graph, weighting, tMode);
+        if (flagEncoder.hasEncodedValue(flagEncoder.toString()+"-conditional_access")) {
+            inEdgeExplorer = graph.createEdgeExplorer(ConditionalAccessEdgeFilter.inEdges(flagEncoder));
+            outEdgeExplorer = graph.createEdgeExplorer(ConditionalAccessEdgeFilter.outEdges(flagEncoder));
+        }
         if (!weighting.isTimeDependent())
             throw new RuntimeException("A time-dependent routing algorithm requires a time-dependent weighting.");
     }

--- a/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AbstractFlagEncoder.java
@@ -24,6 +24,7 @@ import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.reader.osm.conditional.ConditionalOSMTagInspector;
 import com.graphhopper.reader.osm.conditional.ConditionalParser;
+import com.graphhopper.reader.osm.conditional.DateRangeParser;
 import com.graphhopper.routing.profiles.*;
 import com.graphhopper.routing.weighting.TurnWeighting;
 import com.graphhopper.storage.IntsRef;
@@ -119,6 +120,8 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     protected void init() {
         // we should move 'OSM to object' logic into the DataReader like OSMReader, but this is a major task as we need to convert OSM format into kind of a standard/generic format
         ConditionalOSMTagInspector conditionalTagInspector = new ConditionalOSMTagInspector(restrictions, restrictedValues, intendedValues);
+        conditionalTagInspector.addValueParser(new DateRangeParser());
+        //DateTime parser needs to go last = have highest priority in order to allow for storing unevaluated conditionals
         conditionalTagInspector.addValueParser(ConditionalParser.createDateTimeParser());
         this.conditionalTagInspector = conditionalTagInspector;
     }
@@ -658,22 +661,24 @@ public abstract class AbstractFlagEncoder implements FlagEncoder {
     }
 
     public EncodingManager.Access isRestrictedWayConditionallyPermitted(ReaderWay way) {
-        if (getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way))
-            if (getConditionalTagInspector().isConditionLazyEvaluated())
-                return EncodingManager.Access.CONDITIONAL;
-            else
-                return EncodingManager.Access.WAY;
-        else
-            return EncodingManager.Access.CAN_SKIP;
+        return isRestrictedWayConditionallyPermitted(way, EncodingManager.Access.WAY);
+    }
+
+    public EncodingManager.Access isRestrictedWayConditionallyPermitted(ReaderWay way, EncodingManager.Access accept) {
+        return getConditionalAccess(way, accept, true);
     }
 
     public EncodingManager.Access isPermittedWayConditionallyRestricted(ReaderWay way) {
-        if (getConditionalTagInspector().isPermittedWayConditionallyRestricted(way))
-            if (getConditionalTagInspector().isConditionLazyEvaluated())
-                return EncodingManager.Access.CONDITIONAL;
-            else
-                return EncodingManager.Access.CAN_SKIP;
+        return getConditionalAccess(way, EncodingManager.Access.WAY, false);
+    }
+
+    private EncodingManager.Access getConditionalAccess(ReaderWay way, EncodingManager.Access accept, boolean permissive) {
+        ConditionalTagInspector conditionalTagInspector = getConditionalTagInspector();
+        boolean access = permissive ? conditionalTagInspector.isRestrictedWayConditionallyPermitted(way) :
+                !conditionalTagInspector.isPermittedWayConditionallyRestricted(way);
+        if (conditionalTagInspector.hasLazyEvaluatedConditions())
+            return access ? EncodingManager.Access.PERMITTED : EncodingManager.Access.RESTRICTED;
         else
-            return EncodingManager.Access.WAY;
+            return access ? accept : EncodingManager.Access.CAN_SKIP;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -251,14 +251,8 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
                 accept = EncodingManager.Access.WAY;
 
             if (!accept.canSkip()) {
-                if (way.hasTag(restrictions, restrictedValues)) {
-                    if (getConditionalTagInspector().isRestrictedWayConditionallyPermitted(way)) {
-                        if (getConditionalTagInspector().isConditionLazyEvaluated())
-                            return EncodingManager.Access.CONDITIONAL;
-                    }
-                    else
-                        return EncodingManager.Access.CAN_SKIP;
-                }
+                if (way.hasTag(restrictions, restrictedValues))
+                    accept = isRestrictedWayConditionallyPermitted(way, accept);
                 return accept;
             }
 

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -267,7 +267,7 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
 
             // TODO: save conditional speeds only if their value is different from the default speed
             if (getConditionalSpeedInspector().hasConditionalSpeed(way))
-                if (getConditionalSpeedInspector().isConditionLazyEvaluated())
+                if (getConditionalSpeedInspector().hasLazyEvaluatedConditions())
                     conditionalSpeedEncoder.setBool(false, edgeFlags, true);
                 else
                     // conditional maxspeed overrides unconditional one
@@ -279,15 +279,16 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
             if (speedTwoDirections)
                 setSpeed(true, edgeFlags, speed);
 
+            boolean access = !accept.isRestricted();
             boolean isRoundabout = roundaboutEnc.getBool(false, edgeFlags);
             if (isOneway(way) || isRoundabout) {
                 if (isForwardOneway(way))
-                    accessEnc.setBool(false, edgeFlags, true);
+                    accessEnc.setBool(false, edgeFlags, access);
                 if (isBackwardOneway(way))
-                    accessEnc.setBool(true, edgeFlags, true);
+                    accessEnc.setBool(true, edgeFlags, access);
             } else {
-                accessEnc.setBool(false, edgeFlags, true);
-                accessEnc.setBool(true, edgeFlags, true);
+                accessEnc.setBool(false, edgeFlags, access);
+                accessEnc.setBool(true, edgeFlags, access);
             }
 
             if (accept.isConditional())

--- a/core/src/main/java/com/graphhopper/routing/util/ConditionalAccessEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/ConditionalAccessEdgeFilter.java
@@ -1,102 +1,120 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.graphhopper.routing.util;
 
-import ch.poole.conditionalrestrictionparser.Condition;
-import ch.poole.conditionalrestrictionparser.ConditionalRestrictionParser;
-import ch.poole.conditionalrestrictionparser.Restriction;
-import com.graphhopper.routing.EdgeKeys;
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
-import com.graphhopper.util.DateTimeHelper;
-import com.graphhopper.storage.ConditionalEdgesMap;
-import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.util.EdgeIteratorState;
 
-import java.io.ByteArrayInputStream;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
- * Filter out temporarily blocked edges
- *
+ * @author Peter Karich
  * @author Andrzej Oles
  */
-public class ConditionalAccessEdgeFilter implements TimeDependentEdgeFilter {
-    private final BooleanEncodedValue conditionalEnc;
-    private final ConditionalEdgesMap conditionalEdges;
-    private final boolean fwd;
+public class ConditionalAccessEdgeFilter implements EdgeFilter {
+    private static int DEFAULT_FILTER_ID = 0;
     private final boolean bwd;
-    private final DateTimeHelper dateTimeHelper;
+    private final boolean fwd;
+    private final BooleanEncodedValue accessEnc;
+    private final BooleanEncodedValue conditionalEnc;
+    /**
+     * Used to be able to create non-equal filter instances with equal access encoder and fwd/bwd flags.
+     */
+    private int filterId;
 
-    public ConditionalAccessEdgeFilter(GraphHopperStorage graph, FlagEncoder encoder) {
-        this(graph, encoder.toString());
-    }
-
-    public ConditionalAccessEdgeFilter(GraphHopperStorage graph, String encoderName) {
-        this(graph, encoderName, true, true);
-    }
-
-    ConditionalAccessEdgeFilter(GraphHopperStorage graph, String encoderName, boolean fwd, boolean bwd) {
-        EncodingManager encodingManager = graph.getEncodingManager();
-        conditionalEnc = encodingManager.getBooleanEncodedValue(EncodingManager.getKey(encoderName, "conditional_access"));
-        conditionalEdges = graph.getConditionalAccess(encoderName);
+    private ConditionalAccessEdgeFilter(BooleanEncodedValue accessEnc, BooleanEncodedValue conditionalEnc, boolean fwd, boolean bwd, int filterId) {
+        this.accessEnc = accessEnc;
+        this.conditionalEnc = conditionalEnc;
         this.fwd = fwd;
         this.bwd = bwd;
-        this.dateTimeHelper = new DateTimeHelper(graph);
+        this.filterId = filterId;
+    }
+
+    private ConditionalAccessEdgeFilter(FlagEncoder flagEncoder, boolean fwd, boolean bwd, int filterId) {
+        this(flagEncoder.getAccessEnc(), flagEncoder.getBooleanEncodedValue(flagEncoder.toString()+"-conditional_access"), fwd, bwd, filterId);
+    }
+
+    public static ConditionalAccessEdgeFilter outEdges(BooleanEncodedValue accessEnc, BooleanEncodedValue conditionalEnc) {
+        return new ConditionalAccessEdgeFilter(accessEnc, conditionalEnc, true, false, DEFAULT_FILTER_ID);
+    }
+
+    public static ConditionalAccessEdgeFilter inEdges(BooleanEncodedValue accessEnc, BooleanEncodedValue conditionalEnc) {
+        return new ConditionalAccessEdgeFilter(accessEnc, conditionalEnc, false, true, DEFAULT_FILTER_ID);
+    }
+
+    /**
+     * Accepts all edges that are either forward or backward for the given flag encoder.
+     * Edges where neither one of the flags is enabled will still not be accepted. If you need to retrieve all edges
+     * regardless of their encoding use {@link EdgeFilter#ALL_EDGES} instead.
+     */
+    public static ConditionalAccessEdgeFilter allEdges(BooleanEncodedValue accessEnc, BooleanEncodedValue conditionalEnc) {
+        return new ConditionalAccessEdgeFilter(accessEnc, conditionalEnc, true, true, DEFAULT_FILTER_ID);
+    }
+
+    public static ConditionalAccessEdgeFilter outEdges(FlagEncoder flagEncoder) {
+        return new ConditionalAccessEdgeFilter(flagEncoder, true, false, DEFAULT_FILTER_ID);
+    }
+
+    public static ConditionalAccessEdgeFilter inEdges(FlagEncoder flagEncoder) {
+        return new ConditionalAccessEdgeFilter(flagEncoder, false, true, DEFAULT_FILTER_ID);
+    }
+
+    public static ConditionalAccessEdgeFilter allEdges(FlagEncoder flagEncoder) {
+        return new ConditionalAccessEdgeFilter(flagEncoder, true, true, DEFAULT_FILTER_ID);
+    }
+
+    public ConditionalAccessEdgeFilter setFilterId(int filterId) {
+        this.filterId = filterId;
+        return this;
+    }
+
+    public BooleanEncodedValue getAccessEnc() {
+        return accessEnc;
     }
 
     @Override
-    public final boolean accept(EdgeIteratorState iter, long time) {
-        if (fwd && iter.get(conditionalEnc) || bwd && iter.getReverse(conditionalEnc)) {
-            int edgeId = EdgeKeys.getOriginalEdge(iter);
-            // for now the filter is used only in the context of fwd search so only edges going out of the base node are explored
-            ZonedDateTime zonedDateTime = dateTimeHelper.getZonedDateTime(iter, time);
-            String value = conditionalEdges.getValue(edgeId);
-            return accept(value, zonedDateTime);
-        }
-        return true;
-    }
-
-    boolean accept(String conditional, ZonedDateTime zonedDateTime) {
-        boolean matchValue = false;
-
-        try {
-            ConditionalRestrictionParser crparser = new ConditionalRestrictionParser(new ByteArrayInputStream(conditional.getBytes()));
-
-            ArrayList<Restriction> restrictions = crparser.restrictions();
-
-            // iterate over restrictions starting from the last one in order to match to the most specific one
-            for (int i = restrictions.size() - 1 ; i >= 0; i--) {
-                Restriction restriction = restrictions.get(i);
-
-                matchValue = "yes".equals(restriction.getValue());
-
-                List<Condition> conditions = restriction.getConditions();
-
-                // stop as soon as time matches the combined conditions
-                if (TimeDependentConditionalEvaluator.match(conditions, zonedDateTime))
-                    return matchValue;
-            }
-
-            // no restrictions with matching conditions found
-            return !matchValue;
-
-        } catch (ch.poole.conditionalrestrictionparser.ParseException e) {
-            //nop
-        }
-
-        return false;
-    }
-
-    public boolean acceptsBackward() {
-        return bwd;
-    }
-
-    public boolean acceptsForward() {
-        return fwd;
+    public final boolean accept(EdgeIteratorState iter) {
+        return fwd && iter.get(accessEnc) || bwd && iter.getReverse(accessEnc) || fwd && iter.get(conditionalEnc) || bwd && iter.getReverse(conditionalEnc);
     }
 
     @Override
     public String toString() {
-        return conditionalEnc + ", bwd:" + bwd + ", fwd:" + fwd;
+        return accessEnc.toString() + ", " + conditionalEnc.toString() + ", bwd:" + bwd + ", fwd:" + fwd;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ConditionalAccessEdgeFilter that = (ConditionalAccessEdgeFilter) o;
+
+        if (bwd != that.bwd) return false;
+        if (fwd != that.fwd) return false;
+        if (filterId != that.filterId) return false;
+        return accessEnc.equals(that.accessEnc) && conditionalEnc.equals(that.conditionalEnc);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (bwd ? 1 : 0);
+        result = 31 * result + (fwd ? 1 : 0);
+        result = 31 * result + accessEnc.hashCode();
+        result = 31 * result + conditionalEnc.hashCode();
+        result = 31 * result + filterId;
+        return result;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -446,7 +446,7 @@ public class EncodingManager implements EncodedValueLookup {
         for (AbstractFlagEncoder encoder : edgeEncoders) {
             acceptWay.put(encoder.toString(), encoder.getAccess(way));
         }
-        return acceptWay.hasAccepted() || acceptWay.hasConditional();
+        return acceptWay.hasAccepted();
     }
 
     public static class AcceptWay {
@@ -470,7 +470,7 @@ public class EncodingManager implements EncodedValueLookup {
             accessMap.put(key, access);
             if (access != Access.CAN_SKIP)
                 hasAccepted = true;
-            if (access == Access.CONDITIONAL)
+            if (access.isConditional())
                 hasConditional = true;
             return this;
         }
@@ -503,7 +503,7 @@ public class EncodingManager implements EncodedValueLookup {
     }
 
     public enum Access {
-        WAY, FERRY, OTHER, CAN_SKIP, CONDITIONAL;
+        WAY, FERRY, OTHER, CAN_SKIP, PERMITTED, RESTRICTED;
 
         public boolean isFerry() {
             return this.ordinal() == FERRY.ordinal();
@@ -521,8 +521,16 @@ public class EncodingManager implements EncodedValueLookup {
             return this.ordinal() == CAN_SKIP.ordinal();
         }
 
+        public boolean isPermitted() {
+            return this.ordinal() == PERMITTED.ordinal();
+        }
+
+        public boolean isRestricted() {
+            return this.ordinal() == RESTRICTED.ordinal();
+        }
+
         public boolean isConditional() {
-            return this.ordinal() == CONDITIONAL.ordinal();
+            return isRestricted() || isPermitted();
         }
 
     }

--- a/core/src/main/java/com/graphhopper/routing/util/TimeDependentAccessEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TimeDependentAccessEdgeFilter.java
@@ -1,0 +1,94 @@
+package com.graphhopper.routing.util;
+
+import ch.poole.conditionalrestrictionparser.Condition;
+import ch.poole.conditionalrestrictionparser.ConditionalRestrictionParser;
+import ch.poole.conditionalrestrictionparser.Restriction;
+import com.graphhopper.routing.EdgeKeys;
+import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.util.DateTimeHelper;
+import com.graphhopper.storage.ConditionalEdgesMap;
+import com.graphhopper.storage.GraphHopperStorage;
+import com.graphhopper.util.EdgeIteratorState;
+
+import java.io.ByteArrayInputStream;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Filter out temporarily blocked edges
+ *
+ * @author Andrzej Oles
+ */
+public class TimeDependentAccessEdgeFilter implements TimeDependentEdgeFilter {
+    private final BooleanEncodedValue conditionalEnc;
+    private final ConditionalEdgesMap conditionalEdges;
+    private final boolean fwd;
+    private final boolean bwd;
+    private final DateTimeHelper dateTimeHelper;
+
+    public TimeDependentAccessEdgeFilter(GraphHopperStorage graph, FlagEncoder encoder) {
+        this(graph, encoder.toString());
+    }
+
+    public TimeDependentAccessEdgeFilter(GraphHopperStorage graph, String encoderName) {
+        this(graph, encoderName, true, true);
+    }
+
+    TimeDependentAccessEdgeFilter(GraphHopperStorage graph, String encoderName, boolean fwd, boolean bwd) {
+        EncodingManager encodingManager = graph.getEncodingManager();
+        conditionalEnc = encodingManager.getBooleanEncodedValue(EncodingManager.getKey(encoderName, "conditional_access"));
+        conditionalEdges = graph.getConditionalAccess(encoderName);
+        this.fwd = fwd;
+        this.bwd = bwd;
+        this.dateTimeHelper = new DateTimeHelper(graph);
+    }
+
+    @Override
+    public final boolean accept(EdgeIteratorState iter, long time) {
+        if (fwd && iter.get(conditionalEnc) || bwd && iter.getReverse(conditionalEnc)) {
+            int edgeId = EdgeKeys.getOriginalEdge(iter);
+            // for now the filter is used only in the context of fwd search so only edges going out of the base node are explored
+            ZonedDateTime zonedDateTime = (time == -1) ? null : dateTimeHelper.getZonedDateTime(iter, time);
+            String value = conditionalEdges.getValue(edgeId);
+            return accept(value, zonedDateTime);
+        }
+        return true;
+    }
+
+    boolean accept(String conditional, ZonedDateTime zonedDateTime) {
+        boolean matchValue = false;
+
+        try {
+            ConditionalRestrictionParser crparser = new ConditionalRestrictionParser(new ByteArrayInputStream(conditional.getBytes()));
+
+            ArrayList<Restriction> restrictions = crparser.restrictions();
+
+            // iterate over restrictions starting from the last one in order to match to the most specific one
+            for (int i = restrictions.size() - 1 ; i >= 0; i--) {
+                Restriction restriction = restrictions.get(i);
+
+                matchValue = "yes".equals(restriction.getValue());
+
+                List<Condition> conditions = restriction.getConditions();
+
+                // stop as soon as time matches the combined conditions
+                if (TimeDependentConditionalEvaluator.match(conditions, zonedDateTime))
+                    return matchValue;
+            }
+
+            // no restrictions with matching conditions found
+            return !matchValue;
+
+        } catch (ch.poole.conditionalrestrictionparser.ParseException e) {
+            //nop
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return conditionalEnc + ", bwd:" + bwd + ", fwd:" + fwd;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/TimeDependentConditionalEvaluator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TimeDependentConditionalEvaluator.java
@@ -2,6 +2,8 @@ package com.graphhopper.routing.util;
 
 import ch.poole.conditionalrestrictionparser.Condition;
 import ch.poole.openinghoursparser.*;
+import com.graphhopper.reader.osm.conditional.ConditionalValueParser;
+import com.graphhopper.reader.osm.conditional.DateRangeParser;
 
 import java.io.ByteArrayInputStream;
 import java.time.ZonedDateTime;
@@ -15,10 +17,18 @@ public class TimeDependentConditionalEvaluator {
     public static boolean match(List<Condition> conditions, ZonedDateTime zonedDateTime) {
         for (Condition condition : conditions) {
             try {
-                OpeningHoursParser parser = new OpeningHoursParser(new ByteArrayInputStream(condition.toString().getBytes()));
-                List<Rule> rules = parser.rules(false);
+                boolean matched;
+                if (zonedDateTime==null) {
+                    DateRangeParser dateRangeParser = new DateRangeParser();
+                    matched = dateRangeParser.checkCondition(condition)==ConditionalValueParser.ConditionState.TRUE;
+                }
+                else {
+                    OpeningHoursParser parser = new OpeningHoursParser(new ByteArrayInputStream(condition.toString().getBytes()));
+                    List<Rule> rules = parser.rules(false);
+                    matched = matchRules(rules, zonedDateTime);
+                }
                 // failed to match any of the rules
-                if (!matchRules(rules, zonedDateTime))
+                if (!matched)
                     return false;
             } catch (Exception e) {
                 return false;

--- a/core/src/main/java/com/graphhopper/routing/weighting/TimeDependentAccessWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/TimeDependentAccessWeighting.java
@@ -17,7 +17,7 @@
  */
 package com.graphhopper.routing.weighting;
 
-import com.graphhopper.routing.util.ConditionalAccessEdgeFilter;
+import com.graphhopper.routing.util.TimeDependentAccessEdgeFilter;
 import com.graphhopper.routing.util.FlagEncoder;
 import com.graphhopper.routing.util.HintsMap;
 import com.graphhopper.storage.GraphHopperStorage;
@@ -31,11 +31,11 @@ import com.graphhopper.util.EdgeIteratorState;
  * @author Andrzej Oles
  */
 public class TimeDependentAccessWeighting extends AbstractAdjustedWeighting {
-    private ConditionalAccessEdgeFilter edgeFilter;
+    private TimeDependentAccessEdgeFilter edgeFilter;
 
     public TimeDependentAccessWeighting(Weighting weighting, GraphHopperStorage graph, FlagEncoder encoder) {
         super(weighting);
-        this.edgeFilter = new ConditionalAccessEdgeFilter(graph, encoder);
+        this.edgeFilter = new TimeDependentAccessEdgeFilter(graph, encoder);
     }
 
     @Override

--- a/core/src/test/java/com/graphhopper/reader/osm/conditional/ConditionalOSMTagInspectorTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/conditional/ConditionalOSMTagInspectorTest.java
@@ -20,7 +20,6 @@ package com.graphhopper.reader.osm.conditional;
 import com.graphhopper.reader.ReaderWay;
 import org.junit.Test;
 
-import java.text.ParseException;
 import java.util.*;
 
 import static org.junit.Assert.assertFalse;
@@ -99,15 +98,6 @@ public class ConditionalOSMTagInspectorTest extends CalendarBasedTest {
     }
 
     @Test
-    public void testConditionalAllowanceReject() {
-        ConditionalOSMTagInspector acceptor = getConditionalTagInspector();
-        acceptor.addValueParser(new DateRangeParser(getCalendar(2014, Calendar.MARCH, 10)));
-        ReaderWay way = new ReaderWay(1);
-        way.setTag("vehicle:conditional", "no @ (Mar 10-Aug 14)");
-        assertTrue(acceptor.isPermittedWayConditionallyRestricted(way));
-    }
-
-    @Test
     public void testConditionalSingleDay() {
         ConditionalOSMTagInspector acceptor = getConditionalTagInspector();
         acceptor.addValueParser(new DateRangeParser(getCalendar(2015, Calendar.DECEMBER, 27)));
@@ -126,14 +116,37 @@ public class ConditionalOSMTagInspectorTest extends CalendarBasedTest {
     }
 
     @Test
-    public void testCombinedCondition() throws ParseException {
-        String str = "no @ (10:00-18:00 AND length>5)";
+    public void testConditionalAccessHours() {
         ConditionalOSMTagInspector acceptor = getConditionalTagInspector();
-        acceptor.addValueParser(ConditionalParser.createDateTimeParser());
+        acceptor.addValueParser(new DateRangeParser(getCalendar(2015, Calendar.DECEMBER, 27)));
         ReaderWay way = new ReaderWay(1);
-        way.setTag("vehicle:conditional", "no @ (10:00-18:00 AND length>5)");
+        way.setTag("vehicle:conditional", "no @ (10:00-18:00)");
+        assertFalse(acceptor.isPermittedWayConditionallyRestricted(way));
+        acceptor.addValueParser(ConditionalParser.createDateTimeParser());
+        assertFalse(acceptor.isPermittedWayConditionallyRestricted(way));
+    }
+
+    @Test
+    public void testConditionalAccessLength() {
+        ConditionalOSMTagInspector acceptor = getConditionalTagInspector();
+        acceptor.addValueParser(new DateRangeParser(getCalendar(2015, Calendar.DECEMBER, 27)));
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("vehicle:conditional", "no @ length>5");
         assertFalse(acceptor.isPermittedWayConditionallyRestricted(way));
         acceptor.addValueParser(ConditionalParser.createNumberParser("length", 10));
         assertTrue(acceptor.isPermittedWayConditionallyRestricted(way));
+    }
+
+    @Test
+    public void testCombinedConditionHoursAndLength() {
+        ConditionalOSMTagInspector acceptor = getConditionalTagInspector();
+        acceptor.addValueParser(new DateRangeParser(getCalendar(2015, Calendar.DECEMBER, 27)));
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("vehicle:conditional", "no @ (10:00-18:00 AND length>5)");
+        assertFalse(acceptor.isPermittedWayConditionallyRestricted(way));
+        acceptor.addValueParser(ConditionalParser.createDateTimeParser());
+        assertFalse(acceptor.isPermittedWayConditionallyRestricted(way));
+        acceptor.addValueParser(ConditionalParser.createNumberParser("length", 10));
+        assertFalse(acceptor.isPermittedWayConditionallyRestricted(way));
     }
 }

--- a/core/src/test/java/com/graphhopper/reader/osm/conditional/ConditionalParserTest.java
+++ b/core/src/test/java/com/graphhopper/reader/osm/conditional/ConditionalParserTest.java
@@ -17,7 +17,6 @@
  */
 package com.graphhopper.reader.osm.conditional;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import java.text.ParseException;
@@ -52,23 +51,23 @@ public class ConditionalParserTest extends CalendarBasedTest {
     @Test
     public void testParseConditional() throws ParseException {
         String str = "no @ (2015 Sep 1-2015 Sep 30)";
-        assertFalse(createParser(getCalendar(2015, Calendar.AUGUST, 31)).checkCondition(str));
-        assertTrue(createParser(getCalendar(2015, Calendar.SEPTEMBER, 30)).checkCondition(str));
+        assertFalse(createParser(getCalendar(2015, Calendar.AUGUST, 31)).checkCondition(str).isCheckPassed());
+        assertTrue(createParser(getCalendar(2015, Calendar.SEPTEMBER, 30)).checkCondition(str).isCheckPassed());
     }
 
     @Test
     public void testParseAllowingCondition() throws ParseException {
         assertFalse(createParser(getCalendar(2015, Calendar.JANUARY, 12)).
-                checkCondition("yes @ (2015 Sep 1-2015 Sep 30)"));
+                checkCondition("yes @ (2015 Sep 1-2015 Sep 30)").isCheckPassed());
     }
 
     @Test
     public void testParsingOfLeading0() throws ParseException {
         assertTrue(createParser(getCalendar(2015, Calendar.DECEMBER, 2)).
-                checkCondition("no @ (01.11. - 31.03.)"));
+                checkCondition("no @ (01.11. - 31.03.)").isCheckPassed());
 
         assertTrue(createParser(getCalendar(2015, Calendar.DECEMBER, 2)).
-                checkCondition("no @ (01.11 - 31.03)"));
+                checkCondition("no @ (01.11 - 31.03)").isCheckPassed());
     }
 
     @Test
@@ -82,48 +81,48 @@ public class ConditionalParserTest extends CalendarBasedTest {
         set.add("no");
         ConditionalParser instance = new ConditionalParser(set).
                 setConditionalValueParser(ConditionalParser.createNumberParser("weight", 11));
-        assertTrue(instance.checkCondition("no @weight>10"));
+        assertTrue(instance.checkCondition("no @weight>10").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 10));
-        assertFalse(instance.checkCondition("no @weight>10"));
+        assertFalse(instance.checkCondition("no @weight>10").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 9));
-        assertFalse(instance.checkCondition("no @weight>10"));
+        assertFalse(instance.checkCondition("no @weight>10").isCheckPassed());
 
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 11));
-        assertFalse(instance.checkCondition("no @ weight < 10"));
+        assertFalse(instance.checkCondition("no @ weight < 10").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 10));
-        assertFalse(instance.checkCondition("no @ weight < 10"));
+        assertFalse(instance.checkCondition("no @ weight < 10").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 9));
-        assertTrue(instance.checkCondition("no @ weight < 10"));
+        assertTrue(instance.checkCondition("no @ weight < 10").isCheckPassed());
 
         // equals is ignored for now (not that bad for weight)
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 11));
-        assertFalse(instance.checkCondition("no @ weight <= 10"));
+        assertFalse(instance.checkCondition("no @ weight <= 10").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 10));
-        assertFalse(instance.checkCondition("no @ weight <= 10"));
+        assertFalse(instance.checkCondition("no @ weight <= 10").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 9));
-        assertTrue(instance.checkCondition("no @ weight <= 10"));
+        assertTrue(instance.checkCondition("no @ weight <= 10").isCheckPassed());
 
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 11));
-        assertFalse(instance.checkCondition("no @ weight<=10"));
+        assertFalse(instance.checkCondition("no @ weight<=10").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 10));
-        assertFalse(instance.checkCondition("no @ weight<=10"));
+        assertFalse(instance.checkCondition("no @ weight<=10").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("weight", 9));
-        assertTrue(instance.checkCondition("no @ weight<=10"));
+        assertTrue(instance.checkCondition("no @ weight<=10").isCheckPassed());
 
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("height", 1));
-        assertFalse(instance.checkCondition("no @ height > 2"));
+        assertFalse(instance.checkCondition("no @ height > 2").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("height", 2));
-        assertFalse(instance.checkCondition("no @ height > 2"));
+        assertFalse(instance.checkCondition("no @ height > 2").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("height", 3));
-        assertTrue(instance.checkCondition("no @ height > 2"));
+        assertTrue(instance.checkCondition("no @ height > 2").isCheckPassed());
 
         // unit is allowed according to wiki
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("height", 1));
-        assertFalse(instance.checkCondition("no @ height > 2t"));
+        assertFalse(instance.checkCondition("no @ height > 2t").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("height", 2));
-        assertFalse(instance.checkCondition("no @ height > 2t"));
+        assertFalse(instance.checkCondition("no @ height > 2t").isCheckPassed());
         instance.setConditionalValueParser(ConditionalParser.createNumberParser("height", 3));
-        assertTrue(instance.checkCondition("no @ height > 2t"));
+        assertTrue(instance.checkCondition("no @ height > 2t").isCheckPassed());
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/routing/util/TimeDependentAccessEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/TimeDependentAccessEdgeFilterTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.*;
 /**
  * @author Andrzej Oles
  */
-public class ConditionalAccessEdgeFilterTest {
+public class TimeDependentAccessEdgeFilterTest {
     private static final TimeZoneMap timeZoneMap = TimeZoneMap.forRegion(52, 13, 53, 14);
 
     private final CarFlagEncoder encoder = new CarFlagEncoder();
@@ -46,11 +46,11 @@ public class ConditionalAccessEdgeFilterTest {
     private final NodeAccess nodeAccess = graph.getNodeAccess();
     private final TimeDependentEdgeFilter filter;
 
-    public ConditionalAccessEdgeFilterTest() {
+    public TimeDependentAccessEdgeFilterTest() {
         nodeAccess.setNode(0, 52, 13);
         nodeAccess.setNode(1, 53, 14);
         graph.setTimeZoneMap(timeZoneMap);
-        filter = new ConditionalAccessEdgeFilter(graph, encoder);
+        filter = new TimeDependentAccessEdgeFilter(graph, encoder);
     }
 
     private EdgeIteratorState createConditionalEdge(boolean closed, String conditional) {

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -464,7 +464,7 @@ public class OSMReader implements DataReader {
         if (acceptWay.hasConditional()) {
             for (FlagEncoder encoder : encodingManager.fetchEdgeEncoders()) {
                 String encoderName = encoder.toString();
-                if (acceptWay.getAccess(encoderName) == EncodingManager.Access.CONDITIONAL) {
+                if (acceptWay.getAccess(encoderName).isConditional()) {
                     String value = ((AbstractFlagEncoder) encoder).getConditionalTagInspector().getTagValue();
                     ((GraphHopperStorage) ghStorage).getConditionalAccess(encoderName).addEdges(createdEdges, value);
                 }
@@ -479,7 +479,7 @@ public class OSMReader implements DataReader {
             if (encodingManager.hasEncodedValue(encoderName) && encodingManager.getBooleanEncodedValue(encoderName).getBool(false, edgeFlags)) {
                 ConditionalSpeedInspector conditionalSpeedInspector = ((AbstractFlagEncoder) encoder).getConditionalSpeedInspector();
 
-                if (conditionalSpeedInspector.isConditionLazyEvaluated()) {
+                if (conditionalSpeedInspector.hasLazyEvaluatedConditions()) {
                     String value = conditionalSpeedInspector.getTagValue();
                     ((GraphHopperStorage) ghStorage).getConditionalSpeed(encoder).addEdges(createdEdges, value);
                 }


### PR DESCRIPTION
Addresses https://github.com/GIScience/openrouteservice/issues/827 by restoring the original way of handling conditional access restrictions. Now edges with time-dependent access restrictions are not only marked as lazy-evaluated, but their default access is being evaluated at graph build time as well. The default value determined at graph build time can then be used for non time-dependent routing.