### PR TITLE
change to https URL for CGIAR

### DIFF
--- a/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/CGIARProvider.java
@@ -54,7 +54,7 @@ public class CGIARProvider extends AbstractTiffElevationProvider {
 
     public CGIARProvider(String cacheDir) {
         // Alternative URLs for the CGIAR data can be found in #346
-        super("http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/",
+        super("https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/",
                 cacheDir.isEmpty() ? "/tmp/cgiar" : cacheDir,
                 "GraphHopper CGIARReader",
                 6000, 6000,


### PR DESCRIPTION
fixes https://github.com/GIScience/openrouteservice/issues/845, https://github.com/GIScience/openrouteservice/issues/839
fixes #34 

When I tried locally it gave me `NullPointerException` when building ORS with patched GH:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project openrouteservice: Fatal error compiling: CompilerException: NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project openrouteservice: Fatal error compiling
```

But I'm a bit rusty here as well..