### PR TITLE
Use reverseDirection parameter for Dijkstra and TDDijkstra

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/Dijkstra.java
+++ b/core/src/main/java/com/graphhopper/routing/Dijkstra.java
@@ -78,7 +78,7 @@ public class Dijkstra extends AbstractRoutingAlgorithm {
     }
 
     protected void runAlgo() {
-        EdgeExplorer explorer = outEdgeExplorer;
+        EdgeExplorer explorer = reverseDirection ? inEdgeExplorer : outEdgeExplorer;
         while (true) {
             visitedNodes++;
             if (isMaxVisitedNodesExceeded() || finished())
@@ -92,7 +92,7 @@ public class Dijkstra extends AbstractRoutingAlgorithm {
 
                 // ORS-GH MOD START
                 // REMOVED: causes test failure, investigate
-                double tmpWeight = weighting.calcWeight(iter, false, currEdge.edge) + currEdge.weight;
+                double tmpWeight = weighting.calcWeight(iter, reverseDirection, currEdge.edge) + currEdge.weight;
                 // Modification by Maxim Rylov: use originalEdge as the previousEdgeId
 //                double tmpWeight = weighting.calcWeight(iter, reverseDirection, currEdge.originalEdge) + currEdge.weight;
                 // ORS-GH MOD END
@@ -146,7 +146,7 @@ public class Dijkstra extends AbstractRoutingAlgorithm {
         if (currEdge == null || !finished())
             return createEmptyPath();
 
-        return new Path(graph, weighting).
+        return new Path(graph, weighting, reverseDirection).
                 setWeight(currEdge.weight).setSPTEntry(currEdge).extract();
     }
 

--- a/core/src/main/java/com/graphhopper/routing/Path.java
+++ b/core/src/main/java/com/graphhopper/routing/Path.java
@@ -65,6 +65,7 @@ public class Path {
     protected boolean reverseOrder = true;
     protected long time;
     protected GHLongArrayList times;
+    private boolean reverse = false;
     /**
      * Shortest path tree entry
      */
@@ -87,6 +88,11 @@ public class Path {
         this.encoder = weighting.getFlagEncoder();
         this.edgeIds = new GHIntArrayList();
         this.times = new GHLongArrayList();
+    }
+
+    public Path(Graph graph, Weighting weighting, boolean reverse) {
+        this(graph, weighting);
+        this.reverse = reverse;
     }
 
     /**
@@ -221,7 +227,7 @@ public class Path {
             // the reverse search needs the next edge
             nextEdgeValid = EdgeIterator.Edge.isValid(currEdge.parent.edge);
             nextEdge = nextEdgeValid ? currEdge.parent.edge : EdgeIterator.NO_EDGE;
-            processEdge(currEdge.edge, currEdge.adjNode, nextEdge);
+            processEdge(currEdge.edge, currEdge.adjNode, nextEdge, reverse);
             currEdge = currEdge.parent;
         }
 
@@ -254,11 +260,15 @@ public class Path {
      *
      * @param prevEdgeId the edge that comes before edgeId: --prevEdgeId-x-edgeId-->adjNode
      */
-    protected void processEdge(int edgeId, int adjNode, int prevEdgeId) {
+    protected void processEdge(int edgeId, int adjNode, int prevEdgeId, boolean reverse) {
         EdgeIteratorState iter = graph.getEdgeIteratorState(edgeId, adjNode);
         distance += iter.getDistance();
-        addTime(weighting.calcMillis(iter, false, prevEdgeId));
+        addTime(weighting.calcMillis(iter, reverse, prevEdgeId));
         addEdge(edgeId);
+    }
+
+    protected void processEdge(int edgeId, int adjNode, int prevEdgeId) {
+        processEdge(edgeId, adjNode, prevEdgeId, false);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/TDDijkstra.java
+++ b/core/src/main/java/com/graphhopper/routing/TDDijkstra.java
@@ -34,7 +34,6 @@ import com.graphhopper.util.Parameters;
  * @author Andrzej Oles
  */
 public class TDDijkstra extends Dijkstra {
-    private boolean reverse = false;
 
     public TDDijkstra(Graph graph, Weighting weighting, TraversalMode tMode) {
         super(graph, weighting, tMode);
@@ -45,8 +44,8 @@ public class TDDijkstra extends Dijkstra {
     @Override
     public Path calcPath(int from, int to, long at) {
         checkAlreadyRun();
-        int source = reverse ? to : from;
-        int target = reverse ? from : to;
+        int source = reverseDirection ? to : from;
+        int target = reverseDirection ? from : to;
         this.to = target;
         currEdge = new SPTEntry(source, 0);
         currEdge.time = at;
@@ -59,7 +58,7 @@ public class TDDijkstra extends Dijkstra {
 
     @Override
     protected void runAlgo() {
-        EdgeExplorer explorer = reverse ? inEdgeExplorer : outEdgeExplorer;
+        EdgeExplorer explorer = reverseDirection ? inEdgeExplorer : outEdgeExplorer;
         while (true) {
             visitedNodes++;
             if (isMaxVisitedNodesExceeded() || finished())
@@ -71,11 +70,11 @@ public class TDDijkstra extends Dijkstra {
                 if (!accept(iter, currEdge.edge))
                     continue;
 
-                double tmpWeight = weighting.calcWeight(iter, reverse, currEdge.edge, currEdge.time) + currEdge.weight;
+                double tmpWeight = weighting.calcWeight(iter, reverseDirection, currEdge.edge, currEdge.time) + currEdge.weight;
                 if (Double.isInfinite(tmpWeight)) {
                     continue;
                 }
-                int traversalId = traversalMode.createTraversalId(iter, reverse);
+                int traversalId = traversalMode.createTraversalId(iter, reverseDirection);
 
                 SPTEntry nEdge = fromMap.get(traversalId);
                 if (nEdge == null) {
@@ -89,7 +88,7 @@ public class TDDijkstra extends Dijkstra {
                     continue;
 
                 nEdge.parent = currEdge;
-                nEdge.time = (reverse ? -1 : 1) * weighting.calcMillis(iter, reverse, currEdge.edge, currEdge.time) + currEdge.time;
+                nEdge.time = (reverseDirection ? -1 : 1) * weighting.calcMillis(iter, reverseDirection, currEdge.edge, currEdge.time) + currEdge.time;
                 fromHeap.add(nEdge);
 
                 updateBestPath(iter, nEdge, traversalId);
@@ -109,7 +108,7 @@ public class TDDijkstra extends Dijkstra {
         if (currEdge == null || !finished())
             return createEmptyPath();
 
-        return new PathTD(graph, weighting).setReverse(reverse).
+        return new PathTD(graph, weighting).setReverse(reverseDirection).
                 setWeight(currEdge.weight).setSPTEntry(currEdge).extract();
     }
 
@@ -119,6 +118,6 @@ public class TDDijkstra extends Dijkstra {
     }
 
     public void reverse() {
-        reverse = !reverse;
+        reverseDirection = !reverseDirection;
     }
 }


### PR DESCRIPTION
Use the `reverseDirection` parameter to make goal to start Dijkstra. Necessary for reversible (time dependent) isochrones.