### PR TITLE
Allow conditionals to be optional

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -1015,7 +1015,7 @@ public class GraphHopper implements GraphHopperAPI {
         }
 
         else if ("td_fastest".equalsIgnoreCase(weightingStr)) {
-            weighting = encodingManager.hasEncodedValue(encodingManager.getKey(encoder, "conditional_speed"))
+            weighting = encodingManager.hasEncodedValue(EncodingManager.getKey(encoder, ConditionalEdges.SPEED))
                     ? new TimeDependentFastestWeighting(encoder, hints, new ConditionalSpeedCalculator(ghStorage, encoder))
                     : new TimeDependentFastestWeighting(encoder, hints);
         }
@@ -1055,7 +1055,7 @@ public class GraphHopper implements GraphHopperAPI {
      */
     public Weighting createTimeDependentAccessWeighting(Weighting weighting, String algo) {
         FlagEncoder flagEncoder = weighting.getFlagEncoder();
-        if (encodingManager.hasEncodedValue(encodingManager.getKey(flagEncoder, "conditional_access")) && isAlgorithmTimeDependent(algo))
+        if (encodingManager.hasEncodedValue(EncodingManager.getKey(flagEncoder, ConditionalEdges.ACCESS)) && isAlgorithmTimeDependent(algo))
             return new TimeDependentAccessWeighting(weighting, ghStorage, flagEncoder);
         else
             return weighting;

--- a/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
+++ b/core/src/main/java/com/graphhopper/routing/InstructionsFromEdges.java
@@ -88,7 +88,6 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
 
     private final int MAX_U_TURN_DISTANCE = 35;
     protected GHLongArrayList times;
-    private boolean hasTimes;
     // ORS-GH MOD START
     private PathProcessor mPathProcessor = PathProcessor.DEFAULT;
 //    public InstructionsFromEdges(int tmpNode, Graph graph, Weighting weighting, FlagEncoder encoder,
@@ -114,7 +113,6 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
         outEdgeExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.outEdges(encoder));
         crossingExplorer = graph.createEdgeExplorer(DefaultEdgeFilter.allEdges(encoder));
         this.times = times;
-        hasTimes = times == null;
     }
 
     public InstructionsFromEdges(int tmpNode, Graph graph, Weighting weighting, FlagEncoder encoder,
@@ -298,7 +296,7 @@ public class InstructionsFromEdges implements Path.EdgeVisitor {
             prevName = name;
         }
 
-        long time = hasTimes ? times.get(index) : weighting.calcMillis(edge, false, EdgeIterator.NO_EDGE);
+        long time = times.get(index);
         updatePointsAndInstruction(edge, wayGeo, time);
 
         if (wayGeo.getSize() <= 2) {

--- a/core/src/main/java/com/graphhopper/routing/Path.java
+++ b/core/src/main/java/com/graphhopper/routing/Path.java
@@ -260,15 +260,15 @@ public class Path {
      *
      * @param prevEdgeId the edge that comes before edgeId: --prevEdgeId-x-edgeId-->adjNode
      */
-    protected void processEdge(int edgeId, int adjNode, int prevEdgeId, boolean reverse) {
-        EdgeIteratorState iter = graph.getEdgeIteratorState(edgeId, adjNode);
-        distance += iter.getDistance();
-        addTime(weighting.calcMillis(iter, reverse, prevEdgeId));
-        addEdge(edgeId);
-    }
-
     protected void processEdge(int edgeId, int adjNode, int prevEdgeId) {
         processEdge(edgeId, adjNode, prevEdgeId, false);
+    }
+
+    protected void processEdge(int edgeId, int adjNode, int prevOrNextEdgeId, boolean reverse) {
+        EdgeIteratorState iter = graph.getEdgeIteratorState(edgeId, adjNode);
+        distance += iter.getDistance();
+        addTime(weighting.calcMillis(iter, reverse, prevOrNextEdgeId));
+        addEdge(edgeId);
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/PathBidirRef.java
+++ b/core/src/main/java/com/graphhopper/routing/PathBidirRef.java
@@ -114,10 +114,7 @@ public class PathBidirRef extends Path {
      * search: nextEdgeId--x<--edgeId--adjNode
      */
     protected void processEdgeBwd(int edgeId, int adjNode, int nextEdgeId) {
-        EdgeIteratorState edge = graph.getEdgeIteratorState(edgeId, adjNode);
-        distance += edge.getDistance();
-        time += weighting.calcMillis(edge, true, nextEdgeId);
-        addEdge(edgeId);
+        processEdge(edgeId, adjNode, nextEdgeId, true);
     }
 
     private void processTurn(int inEdge, int viaNode, int outEdge) {

--- a/core/src/main/java/com/graphhopper/routing/TDAStar.java
+++ b/core/src/main/java/com/graphhopper/routing/TDAStar.java
@@ -17,7 +17,7 @@
  */
 package com.graphhopper.routing;
 
-import com.graphhopper.routing.util.ConditionalAccessEdgeFilter;
+import com.graphhopper.routing.util.AccessEdgeFilter;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
@@ -36,10 +36,10 @@ public class TDAStar extends AStar {
 
     public TDAStar(Graph graph, Weighting weighting, TraversalMode tMode) {
         super(graph, weighting, tMode);
-        if (flagEncoder.hasEncodedValue(flagEncoder.toString()+"-conditional_access")) {
-            inEdgeExplorer = graph.createEdgeExplorer(ConditionalAccessEdgeFilter.inEdges(flagEncoder));
-            outEdgeExplorer = graph.createEdgeExplorer(ConditionalAccessEdgeFilter.outEdges(flagEncoder));
-        }
+
+        inEdgeExplorer = graph.createEdgeExplorer(AccessEdgeFilter.inEdges(flagEncoder));
+        outEdgeExplorer = graph.createEdgeExplorer(AccessEdgeFilter.outEdges(flagEncoder));
+
         if (!weighting.isTimeDependent())
             throw new RuntimeException("A time-dependent routing algorithm requires a time-dependent weighting.");
     }

--- a/core/src/main/java/com/graphhopper/routing/TDDijkstra.java
+++ b/core/src/main/java/com/graphhopper/routing/TDDijkstra.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.routing;
 
+import com.graphhopper.routing.util.AccessEdgeFilter;
 import com.graphhopper.routing.util.TraversalMode;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.Graph;
@@ -37,6 +38,10 @@ public class TDDijkstra extends Dijkstra {
 
     public TDDijkstra(Graph graph, Weighting weighting, TraversalMode tMode) {
         super(graph, weighting, tMode);
+
+        inEdgeExplorer = graph.createEdgeExplorer(AccessEdgeFilter.inEdges(flagEncoder));
+        outEdgeExplorer = graph.createEdgeExplorer(AccessEdgeFilter.outEdges(flagEncoder));
+
         if (!weighting.isTimeDependent())
             throw new RuntimeException("A time-dependent routing algorithm requires a time-dependent weighting.");
     }

--- a/core/src/main/java/com/graphhopper/routing/ch/Path4CH.java
+++ b/core/src/main/java/com/graphhopper/routing/ch/Path4CH.java
@@ -50,7 +50,7 @@ public class Path4CH extends PathBidirRef {
             @Override
             public void visit(EdgeIteratorState edge, boolean reverse, int prevOrNextEdgeId) {
                 distance += edge.getDistance();
-                time += weighting.calcMillis(edge, reverse, NO_EDGE);
+                addTime(weighting.calcMillis(edge, reverse, NO_EDGE));
                 addEdge(edge.getEdge());
             }
         }, false);

--- a/core/src/main/java/com/graphhopper/routing/util/AccessEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/AccessEdgeFilter.java
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util;
+
+import static com.graphhopper.storage.ConditionalEdges.ACCESS;
+
+/**
+ * Helper class to create an edge explorer accepting restricted edges which are conditionally accessible
+ *
+ * @author Andrzej Oles
+ */
+public class AccessEdgeFilter {
+    public static EdgeFilter outEdges(FlagEncoder flagEncoder) {
+        if (hasConditionalAccess(flagEncoder))
+            return ConditionalAccessEdgeFilter.outEdges(flagEncoder);
+        else
+            return DefaultEdgeFilter.outEdges(flagEncoder);
+    }
+
+    public static EdgeFilter inEdges(FlagEncoder flagEncoder) {
+        if (hasConditionalAccess(flagEncoder))
+            return ConditionalAccessEdgeFilter.inEdges(flagEncoder);
+        else
+            return DefaultEdgeFilter.inEdges(flagEncoder);
+    }
+
+    public static EdgeFilter allEdges(FlagEncoder flagEncoder) {
+        if (hasConditionalAccess(flagEncoder))
+            return ConditionalAccessEdgeFilter.allEdges(flagEncoder);
+        else
+            return DefaultEdgeFilter.allEdges(flagEncoder);
+    }
+
+    private static boolean hasConditionalAccess(FlagEncoder flagEncoder) {
+        return flagEncoder.hasEncodedValue(EncodingManager.getKey(flagEncoder, ACCESS));
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/BikeCommonFlagEncoder.java
@@ -21,6 +21,7 @@ import com.graphhopper.reader.ReaderRelation;
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.profiles.*;
 import com.graphhopper.routing.weighting.PriorityWeighting;
+import com.graphhopper.storage.ConditionalEdges;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.InstructionAnnotation;
@@ -221,7 +222,7 @@ abstract public class BikeCommonFlagEncoder extends AbstractFlagEncoder {
         registerNewEncodedValue.add(unpavedEncoder = new SimpleBooleanEncodedValue(getKey(prefix, "paved"), false));
         registerNewEncodedValue.add(wayTypeEncoder = new UnsignedIntEncodedValue(getKey(prefix, "waytype"), 2, false));
         registerNewEncodedValue.add(priorityWayEncoder = new UnsignedDecimalEncodedValue(getKey(prefix, "priority"), 3, PriorityCode.getFactor(1), false));
-        registerNewEncodedValue.add(conditionalEncoder = new SimpleBooleanEncodedValue(EncodingManager.getKey(prefix, "conditional_access"), false));
+        registerNewEncodedValue.add(conditionalEncoder = new SimpleBooleanEncodedValue(getKey(prefix, ConditionalEdges.ACCESS), false));
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -25,6 +25,7 @@ import com.graphhopper.routing.profiles.BooleanEncodedValue;
 import com.graphhopper.routing.profiles.EncodedValue;
 import com.graphhopper.routing.profiles.SimpleBooleanEncodedValue;
 import com.graphhopper.routing.profiles.UnsignedDecimalEncodedValue;
+import com.graphhopper.storage.ConditionalEdges;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
@@ -179,8 +180,8 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
         super.createEncodedValues(registerNewEncodedValue, prefix, index);
         registerNewEncodedValue.add(speedEncoder = new UnsignedDecimalEncodedValue(EncodingManager.getKey(prefix, "average_speed"), speedBits, speedFactor, speedTwoDirections));
         // FIXME: shouldn't this be directional?
-        registerNewEncodedValue.add(conditionalEncoder = new SimpleBooleanEncodedValue(EncodingManager.getKey(prefix, "conditional_access"), false));
-        registerNewEncodedValue.add(conditionalSpeedEncoder = new SimpleBooleanEncodedValue(EncodingManager.getKey(prefix, "conditional_speed"), false));
+        registerNewEncodedValue.add(conditionalEncoder = new SimpleBooleanEncodedValue(EncodingManager.getKey(prefix, ConditionalEdges.ACCESS), false));
+        registerNewEncodedValue.add(conditionalSpeedEncoder = new SimpleBooleanEncodedValue(EncodingManager.getKey(prefix, ConditionalEdges.SPEED), false));
     }
 
     protected double getSpeed(ReaderWay way) {

--- a/core/src/main/java/com/graphhopper/routing/util/ConditionalAccessEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/ConditionalAccessEdgeFilter.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util;
 
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.storage.ConditionalEdges;
 import com.graphhopper.util.EdgeIteratorState;
 
 /**
@@ -44,7 +45,7 @@ public class ConditionalAccessEdgeFilter implements EdgeFilter {
     }
 
     private ConditionalAccessEdgeFilter(FlagEncoder flagEncoder, boolean fwd, boolean bwd, int filterId) {
-        this(flagEncoder.getAccessEnc(), flagEncoder.getBooleanEncodedValue(flagEncoder.toString()+"-conditional_access"), fwd, bwd, filterId);
+        this(flagEncoder.getAccessEnc(), flagEncoder.getBooleanEncodedValue(EncodingManager.getKey(flagEncoder, ConditionalEdges.ACCESS)), fwd, bwd, filterId);
     }
 
     public static ConditionalAccessEdgeFilter outEdges(BooleanEncodedValue accessEnc, BooleanEncodedValue conditionalEnc) {

--- a/core/src/main/java/com/graphhopper/routing/util/ConditionalSpeedCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/util/ConditionalSpeedCalculator.java
@@ -5,6 +5,7 @@ import ch.poole.conditionalrestrictionparser.Restriction;
 import com.graphhopper.routing.EdgeKeys;
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
 import com.graphhopper.routing.profiles.DecimalEncodedValue;
+import com.graphhopper.storage.ConditionalEdges;
 import com.graphhopper.util.DateTimeHelper;
 import com.graphhopper.storage.ConditionalEdgesMap;
 import com.graphhopper.storage.GraphHopperStorage;
@@ -32,7 +33,7 @@ public class ConditionalSpeedCalculator implements SpeedCalculator{
 
         // time-dependent stuff
         EncodingManager encodingManager = graph.getEncodingManager();
-        String encoderName = encodingManager.getKey(encoder, "conditional_speed");
+        String encoderName = EncodingManager.getKey(encoder, ConditionalEdges.SPEED);
 
         if (!encodingManager.hasEncodedValue(encoderName)) {
             throw new IllegalStateException("No conditional speed associated with the flag encoder");

--- a/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
+++ b/core/src/main/java/com/graphhopper/routing/util/EncodingManager.java
@@ -25,10 +25,7 @@ import com.graphhopper.routing.util.parsers.OSMRoundaboutParser;
 import com.graphhopper.routing.util.parsers.TagParser;
 import com.graphhopper.routing.util.parsers.TagParserFactory;
 import com.graphhopper.routing.weighting.TurnWeighting;
-import com.graphhopper.storage.Directory;
-import com.graphhopper.storage.IntsRef;
-import com.graphhopper.storage.RAMDirectory;
-import com.graphhopper.storage.StorableProperties;
+import com.graphhopper.storage.*;
 import com.graphhopper.util.EdgeIteratorState;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
@@ -683,6 +680,22 @@ public class EncodingManager implements EncodedValueLookup {
     public boolean needsTurnCostsSupport() {
         for (FlagEncoder encoder : edgeEncoders) {
             if (encoder.supports(TurnWeighting.class))
+                return true;
+        }
+        return false;
+    }
+
+    public boolean hasConditionalAccess() {
+        for (FlagEncoder encoder : edgeEncoders) {
+            if (hasEncodedValue(getKey(encoder, ConditionalEdges.ACCESS)))
+                return true;
+        }
+        return false;
+    }
+
+    public boolean hasConditionalSpeed() {
+        for (FlagEncoder encoder : edgeEncoders) {
+            if (hasEncodedValue(getKey(encoder, ConditionalEdges.SPEED)))
                 return true;
         }
         return false;

--- a/core/src/main/java/com/graphhopper/routing/util/TimeDependentAccessEdgeFilter.java
+++ b/core/src/main/java/com/graphhopper/routing/util/TimeDependentAccessEdgeFilter.java
@@ -5,6 +5,7 @@ import ch.poole.conditionalrestrictionparser.ConditionalRestrictionParser;
 import ch.poole.conditionalrestrictionparser.Restriction;
 import com.graphhopper.routing.EdgeKeys;
 import com.graphhopper.routing.profiles.BooleanEncodedValue;
+import com.graphhopper.storage.ConditionalEdges;
 import com.graphhopper.util.DateTimeHelper;
 import com.graphhopper.storage.ConditionalEdgesMap;
 import com.graphhopper.storage.GraphHopperStorage;
@@ -37,7 +38,7 @@ public class TimeDependentAccessEdgeFilter implements TimeDependentEdgeFilter {
 
     TimeDependentAccessEdgeFilter(GraphHopperStorage graph, String encoderName, boolean fwd, boolean bwd) {
         EncodingManager encodingManager = graph.getEncodingManager();
-        conditionalEnc = encodingManager.getBooleanEncodedValue(EncodingManager.getKey(encoderName, "conditional_access"));
+        conditionalEnc = encodingManager.getBooleanEncodedValue(EncodingManager.getKey(encoderName, ConditionalEdges.ACCESS));
         conditionalEdges = graph.getConditionalAccess(encoderName);
         this.fwd = fwd;
         this.bwd = bwd;

--- a/core/src/main/java/com/graphhopper/storage/ConditionalEdges.java
+++ b/core/src/main/java/com/graphhopper/storage/ConditionalEdges.java
@@ -17,6 +17,9 @@ public class ConditionalEdges implements GraphExtension {
 
     private String encoderName;
 
+    public static final String ACCESS = "conditional_access";
+    public static final String SPEED = "conditional_speed";
+
     public ConditionalEdges(EncodingManager encodingManager, String encoderName) {
         this.encodingManager = encodingManager;
         this.encoderName = encoderName;

--- a/core/src/main/java/com/graphhopper/storage/ConditionalEdgesMap.java
+++ b/core/src/main/java/com/graphhopper/storage/ConditionalEdgesMap.java
@@ -126,7 +126,7 @@ public class ConditionalEdgesMap implements GraphExtension {
     @Override
     public boolean loadExisting() {
         if (!edges.loadExisting())
-            throw new IllegalStateException("Unable to load storage 'conditional_access'. corrupt file or directory? " );
+            throw new IllegalStateException("Unable to load storage '" + name + "'. Corrupt file or directory?" );
 
         edgeEntryBytes = edges.getHeader(0);
         edgesCount = edges.getHeader(4);

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -124,10 +124,10 @@ public final class GraphHopperStorage implements GraphStorage, Graph {
             chGraphs.add(new CHGraphImpl(chProfile, dir, baseGraph));
         }
 
-        this.conditionalAccess = new ConditionalEdges(encodingManager, "conditional_access");
+        this.conditionalAccess = new ConditionalEdges(encodingManager, ConditionalEdges.ACCESS);
         this.conditionalAccess.init(this, dir);
 
-        this.conditionalSpeed = new ConditionalEdges(encodingManager, "conditional_speed");
+        this.conditionalSpeed = new ConditionalEdges(encodingManager, ConditionalEdges.SPEED);
         this.conditionalSpeed.init(this, dir);
     }
 

--- a/core/src/test/java/com/graphhopper/routing/util/ConditionalAccessTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/ConditionalAccessTest.java
@@ -96,7 +96,7 @@ public class ConditionalAccessTest extends CalendarBasedTest {
     @Test
     public void setConditionalBit() {
         ReaderWay way = createWay();
-        BooleanEncodedValue conditionalEnc = encodingManager.getBooleanEncodedValue(EncodingManager.getKey(encoder, "conditional_access"));
+        BooleanEncodedValue conditionalEnc = encodingManager.getBooleanEncodedValue(EncodingManager.getKey(encoder, ConditionalEdges.ACCESS));
         assertFalse(createEdge(way).get(conditionalEnc));
         way.setTag("access:conditional", CONDITIONAL);
         assertTrue(createEdge(way).get(conditionalEnc));

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -474,7 +474,7 @@ public class OSMReader implements DataReader {
 
     protected void storeConditionalSpeed(IntsRef edgeFlags, List<EdgeIteratorState> createdEdges) {
         for (FlagEncoder encoder : encodingManager.fetchEdgeEncoders()) {
-            String encoderName = encodingManager.getKey(encoder, "conditional_speed");
+            String encoderName = EncodingManager.getKey(encoder, ConditionalEdges.SPEED);
 
             if (encodingManager.hasEncodedValue(encoderName) && encodingManager.getBooleanEncodedValue(encoderName).getBool(false, edgeFlags)) {
                 ConditionalSpeedInspector conditionalSpeedInspector = ((AbstractFlagEncoder) encoder).getConditionalSpeedInspector();

--- a/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
+++ b/reader-osm/src/main/java/com/graphhopper/reader/osm/OSMReader.java
@@ -464,7 +464,7 @@ public class OSMReader implements DataReader {
         if (acceptWay.hasConditional()) {
             for (FlagEncoder encoder : encodingManager.fetchEdgeEncoders()) {
                 String encoderName = encoder.toString();
-                if (acceptWay.getAccess(encoderName).isConditional()) {
+                if (acceptWay.getAccess(encoderName).isConditional() && encodingManager.hasEncodedValue(EncodingManager.getKey(encoderName, ConditionalEdges.ACCESS))) {
                     String value = ((AbstractFlagEncoder) encoder).getConditionalTagInspector().getTagValue();
                     ((GraphHopperStorage) ghStorage).getConditionalAccess(encoderName).addEdges(createdEdges, value);
                 }


### PR DESCRIPTION
This update features the following two major changes:
- Introduces the logic to create extended storage for OSM conditional access and speed only if the flag encoder for a given profile has the corresponding encoders initialized. This is necessary in order to disable the use of conditionals during time-dependent routing in ORS.
- Fixes the behavior of avoiding recalculation of edge times when generating instructions. This is achieved by storing the times computed by the path processor in an array which is then passed over to the instructions processor.