### PR TITLE
Hook to enable traffic matching before computing landmarks

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -940,6 +940,10 @@ public class GraphHopper implements GraphHopperAPI {
 
         initLocationIndex();
 
+        // ORS-GH MOD START
+        matchTraffic();
+        // ORS-GH MOD END
+
         if (chFactoryDecorator.isEnabled())
             chFactoryDecorator.createPreparations(ghStorage);
         if (!isCHPrepared())
@@ -949,6 +953,10 @@ public class GraphHopper implements GraphHopperAPI {
             lmFactoryDecorator.createPreparations(ghStorage, locationIndex);
         loadOrPrepareLM();
     }
+
+    // ORS-GH MOD START
+    public void matchTraffic() {};
+    // ORS-GH MOD END
 
     private static final String INTERPOLATION_KEY = "prepare.elevation_interpolation.done";
 


### PR DESCRIPTION
As computing landmarks might depend on traffic data, a hook is introduced to inject traffic preprocessing before landmark preparations.