### PR TITLE
consolidate ch.poole-dependencies in pom.xml files

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,14 +73,10 @@
         <dependency>
             <groupId>ch.poole</groupId>
             <artifactId>ConditionalRestrictionParser</artifactId>
-            <!-- TODO ORS: where is this defined? <version>${crparser.version}</version> -->
-            <version>0.3.1</version>
         </dependency>
         <dependency>
             <groupId>ch.poole</groupId>
             <artifactId>OpeningHoursParser</artifactId>
-            <!-- TODO ORS: where is this defined? <version>${ohparser.version}</version> -->
-            <version>0.25.0</version>
         </dependency>
 
         <!-- for using CGIAR: elevation data importing via tif files-->

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <!-- ORS-GH MOD<module>map-matching</module> -->
         <!-- ORS-GH MOD<module>web-bundle</module> -->
         <module>web-api</module>
-        <!-- ORS-GH MOD<module>web</module> -->
+        <module>web</module>
         <!-- ORS-GH MOD<module>client-hc</module> -->
         <!-- ORS-GH MOD<module>navigation</module> -->
         <!-- ORS-GH MOD<module>example</module> -->
@@ -186,6 +186,16 @@
                 <artifactId>hamcrest-library</artifactId>
                 <version>1.3</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>ch.poole</groupId>
+                <artifactId>ConditionalRestrictionParser</artifactId>
+                <version>0.3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.poole</groupId>
+                <artifactId>OpeningHoursParser</artifactId>
+                <version>0.25.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -43,17 +43,6 @@
             <artifactId>dropwizard-testing</artifactId>
             <scope>test</scope>
         </dependency>
-<!-- TODO: need to check if these two are required -->
-        <dependency>
-            <groupId>ch.poole</groupId>
-            <artifactId>ConditionalRestrictionParser</artifactId>
-            <version>${crparser.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.poole</groupId>
-            <artifactId>OpeningHoursParser</artifactId>
-            <version>${ohparser.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Before 32cfae25, Graphhopper used version variables defined in the
<properties>-section of the graphhopper-parent pom.xml.
In #1906 and PR #1912 they decided to switch to maven
<dependencyManagement>.

This allows to declare versions and then use them in any child pom.xml
by only stating group- and artifact Id of the dependency.

Although the two dependencies are only used in graphhopper-core, the
versions are defined consistently in the graphhopper-parent xml.