### PR TITLE
fix: enable overriding of `initCHPreparationHandler`

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -948,7 +948,9 @@ public class GraphHopper {
         return chPreparationHandler;
     }
 
-    private void initCHPreparationHandler() {
+// ORS-GH MOD START change access private -> protected
+    protected void initCHPreparationHandler() {
+// ORS-GH MOD END
         if (chPreparationHandler.hasCHConfigs()) {
             return;
         }


### PR DESCRIPTION
Overriding the method in ORS facilitates modifying the weighting which is being used to prepare CH graphs. This allows, for example, setting of the default HGV vehicle type.

This is a necessary prerequisite for the fix addressing some of the routing issues uncovered by the benchmarks.