### PR TITLE
fix: obtain speed from `speedCalculator` in `fastestWeighting`

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/FastestWeighting.java
@@ -88,7 +88,9 @@ public class FastestWeighting extends AbstractWeighting {
 
     @Override
     public double calcEdgeWeight(EdgeIteratorState edgeState, boolean reverse, long edgeEnterTime) {
-        double speed = reverse ? edgeState.getReverse(avSpeedEnc) : edgeState.get(avSpeedEnc);
+        // ORS-GH MOD START: use speed calculator rather than average speed encoder to obtain edge speed
+        double speed = speedCalculator.getSpeed(edgeState, reverse, edgeEnterTime);
+        // ORS-GH MOD END
         if (speed == 0)
             return Double.POSITIVE_INFINITY;
 


### PR DESCRIPTION
Use speed calculator rather than average speed encoder to obtain edge speed in order to be able to modify edge speed at query time. This is necessary when used with traffic data or when queried with maximum speed parameter.

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
