### PR TITLE
fix: persist conditional access and speed

### DIFF
--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -377,6 +377,14 @@ public class GraphHopperStorage implements Graph, Closeable {
                     throw new IllegalStateException("Cannot load " + cg);
             });
 
+            if (this.conditionalAccess != null) {
+                conditionalAccess.loadExisting();
+            }
+
+            if (this.conditionalSpeed != null) {
+                conditionalSpeed.loadExisting();
+            }
+
 // ORS-GH MOD START add ORS hook
             loadExistingORS();
 // ORS-GH MOD END
@@ -413,6 +421,12 @@ public class GraphHopperStorage implements Graph, Closeable {
         // ORS-GH MOD START - additional code
         if (graphExtensions != null) {
             graphExtensions.flush();
+        }
+        if (conditionalAccess != null) {
+            conditionalAccess.flush();
+        }
+        if (conditionalSpeed != null) {
+            conditionalSpeed.flush();
         }
         // ORS-GH MOD END
     }

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -377,6 +377,7 @@ public class GraphHopperStorage implements Graph, Closeable {
                     throw new IllegalStateException("Cannot load " + cg);
             });
 
+            // ORS-GH MOD START
             if (this.conditionalAccess != null) {
                 conditionalAccess.loadExisting();
             }
@@ -384,6 +385,7 @@ public class GraphHopperStorage implements Graph, Closeable {
             if (this.conditionalSpeed != null) {
                 conditionalSpeed.loadExisting();
             }
+            // ORS-GH MOD END
 
 // ORS-GH MOD START add ORS hook
             loadExistingORS();


### PR DESCRIPTION
flushing and reloading conditional access and speed data hadn't been working, causing ors tests to fail on reloading graphs. Code has been taken from the "Time-dependent routing" PR against 0.13

fixes #61 