### PR TITLE
fix(pom,cve): Upgrade protobuf to the latest version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,7 +98,18 @@
         <dependency>
             <groupId>org.openstreetmap.osmosis</groupId>
             <artifactId>osmosis-osm-binary</artifactId>
-            <version>0.47.3</version>
+            <version>0.48.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.22.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The current version several CVEs and needs a forced upgrade to version 3.22.3.

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
