### PR TITLE
fix(pom,cve): Upgrade commons-compress to 1.23.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -120,6 +120,17 @@
             <groupId>us.dustinj.timezonemap</groupId>
             <artifactId>timezonemap</artifactId>
             <version>4.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.23.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The current version several CVEs and needs a forced upgrade to version 1.23.0.

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
