### PR TITLE
fix(pom,cve): Upgrade xmlgraphics-commons to 2.8

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>xmlgraphics-commons</artifactId>
-            <version>2.3</version>
+            <version>2.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
The current version several CVEs and needs a forced upgrade to version 2.8.

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
