### PR TITLE
fix(cve): Remove dustinj.timezonemap due to CVEs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -128,17 +128,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>us.dustinj.timezonemap</groupId>
-            <artifactId>timezonemap</artifactId>
-            <version>4.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.23.0</version>

--- a/core/src/main/java/com/graphhopper/GraphHopper.java
+++ b/core/src/main/java/com/graphhopper/GraphHopper.java
@@ -51,10 +51,8 @@ import com.graphhopper.util.Parameters.CH;
 import com.graphhopper.util.Parameters.Landmark;
 import com.graphhopper.util.Parameters.Routing;
 import com.graphhopper.util.details.PathDetailsBuilderFactory;
-import com.graphhopper.util.shapes.BBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import us.dustinj.timezonemap.TimeZoneMap;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/GraphHopperStorage.java
@@ -28,7 +28,6 @@ import com.graphhopper.util.Helper;
 import com.graphhopper.util.shapes.BBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import us.dustinj.timezonemap.TimeZoneMap;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -84,16 +83,6 @@ public class GraphHopperStorage implements Graph, Closeable {
         return conditionalSpeed.getConditionalEdgesMap(encoderName);
     }
 
-    // FIXME: temporal solution until an external storage for time zones is introduced.
-    private TimeZoneMap timeZoneMap;
-
-    public TimeZoneMap getTimeZoneMap() {
-        return timeZoneMap;
-    }
-
-    public void setTimeZoneMap(TimeZoneMap timeZoneMap) {
-        this.timeZoneMap = timeZoneMap;
-    }
     // ORS-GH MOD END
 
     // same flush order etc

--- a/core/src/main/java/com/graphhopper/util/DateTimeHelper.java
+++ b/core/src/main/java/com/graphhopper/util/DateTimeHelper.java
@@ -2,7 +2,6 @@ package com.graphhopper.util;
 
 import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.NodeAccess;
-import us.dustinj.timezonemap.TimeZoneMap;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -14,11 +13,9 @@ import java.time.ZonedDateTime;
  */
 public class DateTimeHelper {
     private final NodeAccess nodeAccess;
-    private final TimeZoneMap timeZoneMap;
 
     public DateTimeHelper(GraphHopperStorage graph) {
         this.nodeAccess = graph.getNodeAccess();
-        this.timeZoneMap = graph.getTimeZoneMap();
     }
 
     public ZonedDateTime getZonedDateTime(EdgeIteratorState iter, long time) {
@@ -37,7 +34,7 @@ public class DateTimeHelper {
     }
 
     public ZoneId getZoneId(double lat, double lon) {
-        String zoneId = (timeZoneMap == null) ? "Europe/Berlin" : timeZoneMap.getOverlappingTimeZone(lat, lon).getZoneId();
+        String zoneId = "Europe/Berlin";
         return ZoneId.of(zoneId);
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/TimeDependentAccessEdgeFilterTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/TimeDependentAccessEdgeFilterTest.java
@@ -23,9 +23,7 @@ import com.graphhopper.storage.GraphHopperStorage;
 import com.graphhopper.storage.IntsRef;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.util.EdgeIteratorState;
-import org.junit.Ignore;
 import org.junit.Test;
-import us.dustinj.timezonemap.TimeZoneMap;
 
 import java.time.Month;
 import java.time.ZonedDateTime;
@@ -40,8 +38,6 @@ import static org.junit.Assert.*;
  */
 
 public class TimeDependentAccessEdgeFilterTest {
-    private static final TimeZoneMap timeZoneMap = TimeZoneMap.forRegion(52, 13, 53, 14);
-
     private final CarFlagEncoder encoder = new CarFlagEncoder();
     private final EncodingManager encodingManager = EncodingManager.create(encoder);
     private final GraphHopperStorage graph = new GraphBuilder(encodingManager).create();
@@ -51,7 +47,6 @@ public class TimeDependentAccessEdgeFilterTest {
     public TimeDependentAccessEdgeFilterTest() {
         nodeAccess.setNode(0, 52, 13);
         nodeAccess.setNode(1, 53, 14);
-        graph.setTimeZoneMap(timeZoneMap);
         filter = new TimeDependentAccessEdgeFilter(graph, encoder);
     }
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>ch.poole</groupId>
             <artifactId>ConditionalRestrictionParser</artifactId>
-            <version>${crparser.version}</version>
+            <version>0.3.1</version>
         </dependency>
         <dependency>
             <groupId>ch.poole</groupId>
             <artifactId>OpeningHoursParser</artifactId>
-            <version>${ohparser.version}</version>
+            <version>0.25.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
dustinj.timezonemap is not maintained anymore and introduces more and more vulnerabilities. At the moment we anyway only support one time zone. The removal should therefore not break anything. If more timezones should be reported, we need a better implementation anyways.

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
