### PR TITLE
fix(pom): Fix the group id to org.github.GIScien…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,7 +12,7 @@
         working seamlessly with OpenStreetMap data.
     </description>
     <parent>
-        <groupId>com.graphhopper</groupId>
+        <groupId>org.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
         <version>4.0-SNAPSHOT</version>
     </parent>
@@ -36,9 +36,9 @@
     </licenses>
     <dependencies>
         <dependency>
-            <groupId>com.graphhopper</groupId>
+            <groupId>org.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-api</artifactId>
-            <version>${project.parent.version}</version>
+            <version>4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.carrotsearch</groupId>

--- a/map-matching/pom.xml
+++ b/map-matching/pom.xml
@@ -7,16 +7,16 @@
     <name>GraphHopper Map Matching</name>
 
     <parent>
-        <groupId>com.graphhopper</groupId>
+        <groupId>org.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
         <version>4.0-SNAPSHOT</version>
     </parent>
     
     <dependencies>
         <dependency>
-            <groupId>com.graphhopper</groupId>
+            <groupId>org.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>${project.parent.version}</version>
+            <version>4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.graphhopper</groupId>
+    <groupId>org.github.GIScience.graphhopper</groupId>
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
     <version>4.0-SNAPSHOT</version>

--- a/reader-gtfs/pom.xml
+++ b/reader-gtfs/pom.xml
@@ -8,16 +8,16 @@
     <name>GraphHopper Reader for Gtfs Data</name>
 
     <parent>
-        <groupId>com.graphhopper</groupId>
+        <groupId>org.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
         <version>4.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
-            <groupId>com.graphhopper</groupId>
+            <groupId>org.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>${project.parent.version}</version>
+            <version>4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -53,9 +53,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.graphhopper</groupId>
+            <groupId>org.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>${project.parent.version}</version>
+            <version>4.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/web-api/pom.xml
+++ b/web-api/pom.xml
@@ -10,7 +10,7 @@
     <description>JSON Representation of the API classes</description>
 
     <parent>
-        <groupId>com.graphhopper</groupId>
+        <groupId>org.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
         <version>4.0-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
Fix the group id from com.graphhopper to org.github.GIScience.graphhopper

This is necessary to avoid the wrong native deployment to com.graphhopper in our artifactory. Before, jitpack could override the deployment path but artifactory can't. So, the basic maven pom needs the correct deployment path.

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
