### PR TITLE
feat(gh update dataaccess): Update DataAccess to latest graphhoper version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -189,8 +189,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractSRTMElevationProvider.java
@@ -119,7 +119,7 @@ public abstract class AbstractSRTMElevationProvider extends TileBasedElevationPr
                     demProvider.setHeights(heights);
                     demProvider.setSeaLevel(true);
                     // use small size on disc and in-memory
-                    heights.setSegmentSize(100).create(10).
+                    heights.create(10).
                             flush();
                     return 0;
                 }

--- a/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
+++ b/core/src/main/java/com/graphhopper/reader/dem/AbstractTiffElevationProvider.java
@@ -135,7 +135,7 @@ public abstract class AbstractTiffElevationProvider extends TileBasedElevationPr
                 } catch (IOException e) {
                     demProvider.setSeaLevel(true);
                     // use small size on disc and in-memory
-                    heights.setSegmentSize(100).create(10).
+                    heights.create(10).
                             flush();
                     return 0;
                 }

--- a/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
+++ b/core/src/main/java/com/graphhopper/routing/lm/LandmarkStorage.java
@@ -141,7 +141,7 @@ public class LandmarkStorage {
         // In this sense its even 'better' to use node-based.
         this.traversalMode = TraversalMode.NODE_BASED;
 // ORS-GH MOD START
-        this.landmarkWeightDA = dir.find(getLandmarksFileName() + lmConfig.getName());
+        this.landmarkWeightDA = dir.create(getLandmarksFileName() + lmConfig.getName());
 // ORS-GH MOD END
 
         this.landmarks = landmarks;
@@ -837,6 +837,14 @@ public class LandmarkStorage {
 
         void initLandmarkWeights(final int lmIdx, int lmNodeId, final long rowSize, final int offset);
     }
+
+    /**
+     * For testing only
+     */
+    DataAccess _getInternalDA() {
+        return landmarkWeightDA;
+    }
+
     /**
      * This class is used to calculate landmark location (equally distributed).
      * It derives from DijkstraBidirectionRef, but is only used as forward or backward search.

--- a/core/src/main/java/com/graphhopper/search/NameIndex.java
+++ b/core/src/main/java/com/graphhopper/search/NameIndex.java
@@ -137,10 +137,6 @@ public class NameIndex implements Storable<NameIndex> {
         return names.isClosed();
     }
 
-    public void setSegmentSize(int segments) {
-        names.setSegmentSize(segments);
-    }
-
     public long getCapacity() {
         return names.getCapacity();
     }

--- a/core/src/main/java/com/graphhopper/storage/DataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/DataAccess.java
@@ -125,12 +125,6 @@ public interface DataAccess extends Closeable {
     int getSegmentSize();
 
     /**
-     * In order to increase allocated space one needs to layout the underlying storage in segments.
-     * This is how you can customize the size.
-     */
-    DataAccess setSegmentSize(int bytes);
-
-    /**
      * @return the number of segments.
      */
     int getSegments();

--- a/core/src/main/java/com/graphhopper/storage/Directory.java
+++ b/core/src/main/java/com/graphhopper/storage/Directory.java
@@ -18,7 +18,7 @@
 package com.graphhopper.storage;
 
 import java.nio.ByteOrder;
-import java.util.Collection;
+import java.util.Map;
 
 /**
  * Maintains a collection of DataAccess objects stored at the same location. One GraphStorage per
@@ -36,26 +36,78 @@ public interface Directory {
 
     /**
      * @return the order in which the data is stored
+     * @deprecated
      */
-    ByteOrder getByteOrder();
+    @Deprecated
+    default ByteOrder getByteOrder() {
+        return  ByteOrder.LITTLE_ENDIAN;
+    }
 
     /**
-     * Tries to find the object with that name if not existent it creates one and associates the
-     * location with it. A name is unique in one Directory.
+     * Creates a new DataAccess object with the given name in the location of this Directory. Each name can only
+     * be used once.
      */
-    DataAccess find(String name);
+    DataAccess create(String name);
 
-    DataAccess find(String name, DAType type);
+    /**
+     * @deprecated use {@link #create(String)} instead.
+     */
+    @Deprecated
+    default DataAccess find(String name) {
+        return create(name);
+    }
+
+    /**
+     * @param segmentSize segment size in bytes or -1 to use the default of the corresponding DataAccess implementation
+     */
+    DataAccess create(String name, int segmentSize);
+
+    /**
+     * @deprecated use {@link #create(String, int)} instead.
+     */
+    @Deprecated
+    default DataAccess find(String name, int segmentSize) {
+        return create(name, segmentSize);
+    }
+
+    DataAccess create(String name, DAType type);
+
+    /**
+     * @deprecated use {@link #create(String, DAType)} instead.
+     */
+    @Deprecated
+    default DataAccess find(String name, DAType type) {
+        return create(name, type);
+    }
+
+    DataAccess create(String name, DAType type, int segmentSize);
+
+    /**
+     * @deprecated use {@link #create(String, DAType, int)} instead.
+     */
+    @Deprecated
+    default DataAccess find(String name, DAType type, int segmentSize) {
+        return create(name, type, segmentSize);
+    }
 
     /**
      * Removes the specified object from the directory.
      */
-    void remove(DataAccess da);
+    void remove(String name);
 
+    /**
+     * @deprecated use {@link #remove(String)} instead.
+     */
+    @Deprecated
+    default void remove(DataAccess da) {
+        remove(da.getName());
+    }
     /**
      * @return the default type of a newly created DataAccess object
      */
     DAType getDefaultType();
+
+    DAType getDefaultType(String dataAccess, boolean preferInts);
 
     /**
      * Removes all contained objects from the directory and releases its resources.
@@ -66,11 +118,6 @@ public interface Directory {
      * Releases all allocated resources from the directory without removing backing files.
      */
     void close();
-
-    /**
-     * Returns all created directories.
-     */
-    Collection<DataAccess> getAll();
 
     Directory create();
 }

--- a/core/src/main/java/com/graphhopper/storage/GHDirectory.java
+++ b/core/src/main/java/com/graphhopper/storage/GHDirectory.java
@@ -18,11 +18,10 @@
 package com.graphhopper.storage;
 
 import java.io.File;
-import java.nio.ByteOrder;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
+import static com.graphhopper.storage.DAType.RAM_INT;
+import static com.graphhopper.storage.DAType.RAM_INT_STORE;
 import static com.graphhopper.util.Helper.*;
 
 /**
@@ -32,13 +31,14 @@ import static com.graphhopper.util.Helper.*;
  */
 public class GHDirectory implements Directory {
     protected final String location;
-    private final DAType defaultType;
-    private final ByteOrder byteOrder = ByteOrder.LITTLE_ENDIAN;
-    protected Map<String, DataAccess> map = new HashMap<>();
-    protected Map<String, DAType> types = new HashMap<>();
+    private final DAType typeFallback;
+    // first rule matches => LinkedHashMap
+    private final Map<String, DAType> defaultTypes = new LinkedHashMap<>();
+    private final Map<String, Integer> mmapPreloads = new LinkedHashMap<>();
+    private final Map<String, DataAccess> map = Collections.synchronizedMap(new HashMap<>());
 
     public GHDirectory(String _location, DAType defaultType) {
-        this.defaultType = defaultType;
+        this.typeFallback = defaultType;
         if (isEmpty(_location))
             _location = new File("").getAbsolutePath();
 
@@ -51,53 +51,98 @@ public class GHDirectory implements Directory {
             throw new RuntimeException("file '" + dir + "' exists but is not a directory");
     }
 
-    @Override
-    public ByteOrder getByteOrder() {
-        return byteOrder;
-    }
-
-    public Directory put(String name, DAType type) {
-        if (!name.equals(toLowerCase(name)))
-            throw new IllegalArgumentException("Since 0.7 DataAccess objects does no longer accept upper case names");
-
-        types.put(name, type);
+    /**
+     * Configure the DAType (specified by the value) of a single DataAccess object (specified by the key). For "MMAP" you
+     * can prepend "preload." to the name and specify a percentage which preloads the DataAccess into physical memory of
+     * the specified percentage (only applied for load, not for import).
+     * As keys can be patterns the order is important and the LinkedHashMap is forced as type.
+     */
+    public Directory configure(LinkedHashMap<String, String> config) {
+        for (Map.Entry<String, String> kv : config.entrySet()) {
+            String value = kv.getValue().trim();
+            if (kv.getKey().startsWith("preload."))
+                try {
+                    String pattern = kv.getKey().substring("preload.".length());
+                    mmapPreloads.put(pattern, Integer.parseInt(value));
+                } catch (NumberFormatException ex) {
+                    throw new IllegalArgumentException("DataAccess " + kv.getKey() + " has an incorrect preload value: " + value);
+                }
+            else {
+                String pattern = kv.getKey();
+                defaultTypes.put(pattern, DAType.fromString(value));
+            }
+        }
         return this;
     }
 
-    @Override
-    public DataAccess find(String name) {
-        DAType type = types.get(name);
-        if (type == null)
-            type = defaultType;
+    /**
+     * Returns the preload value or 0 if no patterns match.
+     * See {@link #configure(LinkedHashMap)}
+     */
+    int getPreload(String name) {
+        for (Map.Entry<String, Integer> entry : mmapPreloads.entrySet())
+            if (name.matches(entry.getKey())) return entry.getValue();
+        return 0;
+    }
 
-        return find(name, type);
+    public void loadMMap() {
+        for (DataAccess da : map.values()) {
+            if (!(da instanceof MMapDataAccess))
+                continue;
+            int preload = getPreload(da.getName());
+            if (preload > 0)
+                ((MMapDataAccess) da).load(preload);
+        }
     }
 
     @Override
-    public DataAccess find(String name, DAType type) {
+    public DataAccess create(String name) {
+        return create(name, getDefault(name, typeFallback));
+    }
+
+    @Override
+    public DataAccess create(String name, int segmentSize) {
+        return create(name, getDefault(name, typeFallback), segmentSize);
+    }
+
+    private DAType getDefault(String name, DAType typeFallback) {
+        for (Map.Entry<String, DAType> entry : defaultTypes.entrySet())
+            if (name.matches(entry.getKey())) return entry.getValue();
+        return typeFallback;
+    }
+
+    @Override
+    public DataAccess create(String name, DAType type) {
+        return create(name, type, -1);
+    }
+
+    @Override
+    public DataAccess create(String name, DAType type, int segmentSize) {
         if (!name.equals(toLowerCase(name)))
             throw new IllegalArgumentException("Since 0.7 DataAccess objects does no longer accept upper case names");
 
-        DataAccess da = map.get(name);
-        if (da != null) {
-            if (!type.equals(da.getType()))
-                throw new IllegalStateException("Found existing DataAccess object '" + name
-                        + "' but types did not match. Requested:" + type + ", was:" + da.getType());
-            return da;
-        }
+        if (map.containsKey(name))
+            // we do not allow creating two DataAccess with the same name, because on disk there can only be one DA
+            // per file name
+            try {
+                throw new IllegalStateException("DataAccess " + name + " has already been created");
+            } catch (Exception e){
+                throw e;
+            }
 
+        DataAccess da;
         if (type.isInMemory()) {
             if (type.isInteg()) {
                 if (type.isStoring())
-                    da = new RAMIntDataAccess(name, location, true, byteOrder);
+                    da = new RAMIntDataAccess(name, location, true, segmentSize);
                 else
-                    da = new RAMIntDataAccess(name, location, false, byteOrder);
+                    da = new RAMIntDataAccess(name, location, false, segmentSize);
             } else if (type.isStoring())
-                da = new RAMDataAccess(name, location, true, byteOrder);
+                da = new RAMDataAccess(name, location, true, segmentSize);
             else
-                da = new RAMDataAccess(name, location, false, byteOrder);
+                da = new RAMDataAccess(name, location, false, segmentSize);
         } else if (type.isMMap()) {
-            da = new MMapDataAccess(name, location, byteOrder, type.isAllowWrites());
+            da = new MMapDataAccess(name, location, type.isAllowWrites(), segmentSize);
         } else {
             throw new IllegalArgumentException("DAType not supported " + type);
         }
@@ -124,13 +169,13 @@ public class GHDirectory implements Directory {
     }
 
     @Override
-    public void remove(DataAccess da) {
-        DataAccess old = map.remove(da.getName());
+    public void remove(String name) {
+        DataAccess old = map.remove(name);
         if (old == null)
-            throw new IllegalStateException("Couldn't remove DataAccess: " + da.getName());
+            throw new IllegalStateException("Couldn't remove DataAccess: " + name);
 
-        da.close();
-        removeBackingFile(da, da.getName());
+        old.close();
+        removeBackingFile(old, name);
     }
 
     private void removeBackingFile(DataAccess da, String name) {
@@ -140,11 +185,22 @@ public class GHDirectory implements Directory {
 
     @Override
     public DAType getDefaultType() {
-        return defaultType;
+        return typeFallback;
+    }
+
+    /**
+     * This method returns the default DAType of the specified DataAccess (as string). If preferInts is true then this
+     * method returns e.g. RAM_INT if the type of the specified DataAccess is RAM.
+     */
+    public DAType getDefaultType(String dataAccess, boolean preferInts) {
+        DAType type = getDefault(dataAccess, typeFallback);
+        if (preferInts && type.isInMemory())
+            return type.isStoring() ? RAM_INT_STORE : RAM_INT;
+        return type;
     }
 
     public boolean isStoring() {
-        return defaultType.isStoring();
+        return typeFallback.isStoring();
     }
 
     @Override
@@ -152,11 +208,6 @@ public class GHDirectory implements Directory {
         if (isStoring())
             new File(location).mkdirs();
         return this;
-    }
-
-    @Override
-    public Collection<DataAccess> getAll() {
-        return map.values();
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/MMapDataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/MMapDataAccess.java
@@ -17,7 +17,6 @@
  */
 package com.graphhopper.storage;
 
-import com.graphhopper.util.Constants;
 import com.graphhopper.util.Helper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,18 +25,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.StringTokenizer;
 
 /**
  * A DataAccess implementation using a memory-mapped file, i.e. a facility of the
@@ -61,103 +54,36 @@ public final class MMapDataAccess extends AbstractDataAccess {
 
     private final boolean allowWrites;
     private RandomAccessFile raFile;
-    private List<MappedByteBuffer> segments = new ArrayList<>();
+    private final List<MappedByteBuffer> segments = new ArrayList<>();
 
-    MMapDataAccess(String name, String location, ByteOrder order, boolean allowWrites) {
-        super(name, location, order);
+    MMapDataAccess(String name, String location, boolean allowWrites, int segmentSize) {
+        super(name, location, segmentSize);
         this.allowWrites = allowWrites;
-    }
-
-    public static boolean jreIsMinimumJava9() {
-        final StringTokenizer st = new StringTokenizer(System.getProperty("java.specification.version"), ".");
-        int JVM_MAJOR_VERSION = Integer.parseInt(st.nextToken());
-        int JVM_MINOR_VERSION;
-        if (st.hasMoreTokens()) {
-            JVM_MINOR_VERSION = Integer.parseInt(st.nextToken());
-        } else {
-            JVM_MINOR_VERSION = 0;
-        }
-        return JVM_MAJOR_VERSION > 1 || (JVM_MAJOR_VERSION == 1 && JVM_MINOR_VERSION >= 9);
     }
 
     public static void cleanMappedByteBuffer(final ByteBuffer buffer) {
         // TODO avoid reflection on every call
         try {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
-                @Override
-                public Object run() throws Exception {
-                    if (jreIsMinimumJava9()) {
-                        // >=JDK9 class sun.misc.Unsafe { void invokeCleaner(ByteBuffer buf) }
-                        final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
-                        // fetch the unsafe instance and bind it to the virtual MethodHandle
-                        final Field f = unsafeClass.getDeclaredField("theUnsafe");
-                        f.setAccessible(true);
-                        final Object theUnsafe = f.get(null);
-                        final Method method = unsafeClass.getDeclaredMethod("invokeCleaner", ByteBuffer.class);
-                        try {
-                            method.invoke(theUnsafe, buffer);
-                            return null;
-                        } catch (Throwable t) {
-                            throw new RuntimeException(t);
-                        }
-                    }
-
-                    if (buffer.getClass().getSimpleName().equals("MappedByteBufferAdapter")) {
-                        if (!Constants.ANDROID)
-                            throw new RuntimeException("MappedByteBufferAdapter only supported for Android at the moment");
-
-                        // For Android 4.1 call ((MappedByteBufferAdapter)buffer).free() see #914
-                        Class<?> directByteBufferClass = Class.forName("java.nio.MappedByteBufferAdapter");
-                        callBufferFree(buffer, directByteBufferClass);
-                    } else {
-                        // <=JDK8 class DirectByteBuffer { sun.misc.Cleaner cleaner(Buffer buf) }
-                        //        then call sun.misc.Cleaner.clean
-                        final Class<?> directByteBufferClass = Class.forName("java.nio.DirectByteBuffer");
-                        try {
-                            final Method dbbCleanerMethod = directByteBufferClass.getMethod("cleaner");
-                            dbbCleanerMethod.setAccessible(true);
-                            // call: cleaner = ((DirectByteBuffer)buffer).cleaner()
-                            final Object cleaner = dbbCleanerMethod.invoke(buffer);
-                            if (cleaner != null) {
-                                final Class<?> cleanerMethodReturnType = dbbCleanerMethod.getReturnType();
-                                final Method cleanMethod = cleanerMethodReturnType.getDeclaredMethod("clean");
-                                cleanMethod.setAccessible(true);
-                                // call: ((sun.misc.Cleaner)cleaner).clean()
-                                cleanMethod.invoke(cleaner);
-                            }
-                        } catch (NoSuchMethodException ex2) {
-                            if (Constants.ANDROID)
-                                // For Android 5.1.1 call ((DirectByteBuffer)buffer).free() see #933
-                                callBufferFree(buffer, directByteBufferClass);
-                            else
-                                // ignore if method cleaner or clean is not available
-                                LOGGER.warn("NoSuchMethodException | " + System.getProperty("java.version"), ex2);
-                        }
-                    }
-
-                    return null;
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw new RuntimeException("Unable to unmap the mapped buffer", e);
-        }
-    }
-
-    private static void callBufferFree(ByteBuffer buffer, Class<?> directByteBufferClass)
-            throws InvocationTargetException, IllegalAccessException {
-        try {
-            final Method dbbFreeMethod = directByteBufferClass.getMethod("free");
-            dbbFreeMethod.setAccessible(true);
-            dbbFreeMethod.invoke(buffer);
-        } catch (NoSuchMethodException ex2) {
-            LOGGER.warn("NoSuchMethodException | " + System.getProperty("java.version"), ex2);
+            // >=JDK9 class sun.misc.Unsafe { void invokeCleaner(ByteBuffer buf) }
+            final Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+            // fetch the unsafe instance and bind it to the virtual MethodHandle
+            final Field f = unsafeClass.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            final Object theUnsafe = f.get(null);
+            final Method method = unsafeClass.getDeclaredMethod("invokeCleaner", ByteBuffer.class);
+            try {
+                method.invoke(theUnsafe, buffer);
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException("Unable to unmap the mapped buffer", ex);
         }
     }
 
     private void initRandomAccessFile() {
-        if (raFile != null) {
+        if (raFile != null)
             return;
-        }
 
         try {
             // raFile necessary for loadExisting and create
@@ -174,7 +100,6 @@ public final class MMapDataAccess extends AbstractDataAccess {
         }
         initRandomAccessFile();
         bytes = Math.max(10 * 4, bytes);
-        setSegmentSize(segmentSizeInBytes);
         ensureCapacity(bytes);
         return this;
     }
@@ -309,6 +234,18 @@ public final class MMapDataAccess extends AbstractDataAccess {
         }
     }
 
+    /**
+     * Load memory mapped files into physical memory.
+     */
+    public void load(int percentage) {
+        if (percentage < 0 || percentage > 100)
+            throw new IllegalArgumentException("Percentage for MMapDataAccess.load for " + getName() + " must be in [0,100] but was " + percentage);
+        int max = Math.round(segments.size() * percentage / 100f);
+        for (int i = 0; i < max; i++) {
+            segments.get(i).load();
+        }
+    }
+
     @Override
     public void close() {
         super.close();
@@ -318,65 +255,50 @@ public final class MMapDataAccess extends AbstractDataAccess {
     }
 
     @Override
-    public final void setInt(long bytePos, int value) {
+    public void setInt(long bytePos, int value) {
         int bufferIndex = (int) (bytePos >> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         if (index + 4 > segmentSizeInBytes)
             throw new IllegalStateException("Padding required. Currently an int cannot be distributed over two segments. " + bytePos);
         ByteBuffer byteBuffer = segments.get(bufferIndex);
-        synchronized (byteBuffer) {
-            byteBuffer.putInt(index, value);
-        }
+        byteBuffer.putInt(index, value);
     }
 
     @Override
-    public final int getInt(long bytePos) {
+    public int getInt(long bytePos) {
         int bufferIndex = (int) (bytePos >> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         if (index + 4 > segmentSizeInBytes)
             throw new IllegalStateException("Padding required. Currently an int cannot be distributed over two segments. " + bytePos);
         ByteBuffer byteBuffer = segments.get(bufferIndex);
-        synchronized (byteBuffer) {
-            return byteBuffer.getInt(index);
-        }
+        return byteBuffer.getInt(index);
     }
 
     @Override
-    public final void setShort(long bytePos, short value) {
-        int bufferIndex = (int) (bytePos >>> segmentSizePower);
-        int index = (int) (bytePos & indexDivisor);
-        ByteBuffer byteBuffer = segments.get(bufferIndex);
-        synchronized (byteBuffer) {
-            if (index + 2 > segmentSizeInBytes) {
-                ByteBuffer byteBufferNext = segments.get(bufferIndex + 1);
-                synchronized (byteBufferNext) {
-                    // special case if short has to be written into two separate segments
-                    byteBuffer.put(index, (byte) value);
-                    byteBufferNext.put(0, (byte) (value >>> 8));
-                }
-            } else {
-                byteBuffer.putShort(index, value);
-            }
-        }
-    }
-
-    @Override
-    public final short getShort(long bytePos) {
+    public void setShort(long bytePos, short value) {
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         ByteBuffer byteBuffer = segments.get(bufferIndex);
         if (index + 2 > segmentSizeInBytes) {
             ByteBuffer byteBufferNext = segments.get(bufferIndex + 1);
-            // never lock byteBuffer and byteBufferNext in a different order to avoid deadlocks (shouldn't happen)
-            synchronized (byteBuffer) {
-                synchronized (byteBufferNext) {
-                    return (short) ((byteBufferNext.get(0) & 0xFF) << 8 | byteBuffer.get(index) & 0xFF);
-                }
-            }
+            // special case if short has to be written into two separate segments
+            byteBuffer.put(index, (byte) value);
+            byteBufferNext.put(0, (byte) (value >>> 8));
+        } else {
+            byteBuffer.putShort(index, value);
         }
-        synchronized (byteBuffer) {
-            return byteBuffer.getShort(index);
+    }
+
+    @Override
+    public short getShort(long bytePos) {
+        int bufferIndex = (int) (bytePos >>> segmentSizePower);
+        int index = (int) (bytePos & indexDivisor);
+        ByteBuffer byteBuffer = segments.get(bufferIndex);
+        if (index + 2 > segmentSizeInBytes) {
+            ByteBuffer byteBufferNext = segments.get(bufferIndex + 1);
+            return (short) ((byteBufferNext.get(0) & 0xFF) << 8 | byteBuffer.get(index) & 0xFF);
         }
+        return byteBuffer.getShort(index);
     }
 
     @Override
@@ -386,21 +308,15 @@ public final class MMapDataAccess extends AbstractDataAccess {
         final int index = (int) (bytePos & indexDivisor);
         final int delta = index + length - segmentSizeInBytes;
         final ByteBuffer bb1 = segments.get(bufferIndex);
-        synchronized (bb1) {
-            bb1.position(index);
-            if (delta > 0) {
-                length -= delta;
-                bb1.put(values, 0, length);
-            } else {
-                bb1.put(values, 0, length);
-            }
+        if (delta > 0) {
+            length -= delta;
+            bb1.put(index, values, 0, length);
+        } else {
+            bb1.put(index, values, 0, length);
         }
         if (delta > 0) {
             final ByteBuffer bb2 = segments.get(bufferIndex + 1);
-            synchronized (bb2) {
-                bb2.position(0);
-                bb2.put(values, length, delta);
-            }
+            bb2.put(0, values, length, delta);
         }
     }
 
@@ -411,21 +327,14 @@ public final class MMapDataAccess extends AbstractDataAccess {
         int index = (int) (bytePos & indexDivisor);
         int delta = index + length - segmentSizeInBytes;
         final ByteBuffer bb1 = segments.get(bufferIndex);
-        synchronized (bb1) {
-            bb1.position(index);
-            if (delta > 0) {
-                length -= delta;
-                bb1.get(values, 0, length);
-            } else {
-                bb1.get(values, 0, length);
-            }
-        }
         if (delta > 0) {
+            length -= delta;
+            bb1.get(index, values, 0, length);
+
             final ByteBuffer bb2 = segments.get(bufferIndex + 1);
-            synchronized (bb2) {
-                bb2.position(0);
-                bb2.get(values, length, delta);
-            }
+            bb2.get(0, values, length, delta);
+        } else {
+            bb1.get(index, values, 0, length);
         }
     }
 
@@ -434,10 +343,7 @@ public final class MMapDataAccess extends AbstractDataAccess {
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         final ByteBuffer bb1 = segments.get(bufferIndex);
-        synchronized (bb1) {
-            bb1.position(index);
-            bb1.put(value);
-        }
+        bb1.put(index, value);
     }
 
     @Override
@@ -445,19 +351,14 @@ public final class MMapDataAccess extends AbstractDataAccess {
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         final ByteBuffer bb1 = segments.get(bufferIndex);
-        synchronized (bb1) {
-            bb1.position(index);
-            return bb1.get();
-        }
+        return bb1.get(index);
     }
 
     @Override
     public long getCapacity() {
         long cap = 0;
         for (ByteBuffer bb : segments) {
-            synchronized (bb) {
-                cap += bb.capacity();
-            }
+            cap += bb.capacity();
         }
         return cap;
     }

--- a/core/src/main/java/com/graphhopper/storage/RAMDataAccess.java
+++ b/core/src/main/java/com/graphhopper/storage/RAMDataAccess.java
@@ -20,12 +20,11 @@ package com.graphhopper.storage;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.ByteOrder;
 import java.util.Arrays;
 
 /**
  * This is an in-memory byte-based data structure with the possibility to be stored on flush().
- * Thread safe.
+ * Read thread-safe.
  * <p>
  *
  * @author Peter Karich
@@ -34,8 +33,8 @@ public class RAMDataAccess extends AbstractDataAccess {
     private byte[][] segments = new byte[0][];
     private boolean store;
 
-    RAMDataAccess(String name, String location, boolean store, ByteOrder order) {
-        super(name, location, order);
+    RAMDataAccess(String name, String location, boolean store, int segmentSize) {
+        super(name, location, segmentSize);
         this.store = store;
     }
 
@@ -57,7 +56,6 @@ public class RAMDataAccess extends AbstractDataAccess {
         if (segments.length > 0)
             throw new IllegalThreadStateException("already created");
 
-        setSegmentSize(segmentSizeInBytes);
         ensureCapacity(Math.max(10 * 4, bytes));
         return this;
     }
@@ -84,8 +82,8 @@ public class RAMDataAccess extends AbstractDataAccess {
             segments = newSegs;
         } catch (OutOfMemoryError err) {
             throw new OutOfMemoryError(err.getMessage() + " - problem when allocating new memory. Old capacity: "
-                    + cap + ", new bytes:" + newBytes + ", segmentSizeIntsPower:" + segmentSizePower
-                    + ", new segments:" + segmentsToCreate + ", existing:" + segments.length);
+                                       + cap + ", new bytes:" + newBytes + ", segmentSizeIntsPower:" + segmentSizePower
+                                       + ", new segments:" + segmentsToCreate + ", existing:" + segments.length);
         }
         return true;
     }
@@ -106,14 +104,13 @@ public class RAMDataAccess extends AbstractDataAccess {
             return false;
 
         try {
-            RandomAccessFile raFile = new RandomAccessFile(getFullName(), "r");
-            try {
+            try (RandomAccessFile raFile = new RandomAccessFile(getFullName(), "r")) {
                 long byteCount = readHeader(raFile) - HEADER_OFFSET;
                 if (byteCount < 0)
                     return false;
 
                 raFile.seek(HEADER_OFFSET);
-                // raFile.readInt() <- too slow                
+                // raFile.readInt() <- too slow
                 int segmentCount = (int) (byteCount / segmentSizeInBytes);
                 if (byteCount % segmentSizeInBytes != 0)
                     segmentCount++;
@@ -128,8 +125,6 @@ public class RAMDataAccess extends AbstractDataAccess {
                     segments[s] = bytes;
                 }
                 return true;
-            } finally {
-                raFile.close();
             }
         } catch (IOException ex) {
             throw new RuntimeException("Problem while loading " + getFullName(), ex);
@@ -145,18 +140,15 @@ public class RAMDataAccess extends AbstractDataAccess {
             return;
 
         try {
-            RandomAccessFile raFile = new RandomAccessFile(getFullName(), "rw");
-            try {
+            try (RandomAccessFile raFile = new RandomAccessFile(getFullName(), "rw")) {
                 long len = getCapacity();
                 writeHeader(raFile, len, segmentSizeInBytes);
                 raFile.seek(HEADER_OFFSET);
                 // raFile.writeInt() <- too slow, so copy into byte array
                 for (int s = 0; s < segments.length; s++) {
-                    byte area[] = segments[s];
+                    byte[] area = segments[s];
                     raFile.write(area);
                 }
-            } finally {
-                raFile.close();
             }
         } catch (Exception ex) {
             throw new RuntimeException("Couldn't store bytes to " + toString(), ex);
@@ -175,7 +167,7 @@ public class RAMDataAccess extends AbstractDataAccess {
 
     @Override
     public final int getInt(long bytePos) {
-        assert segmentSizePower > 0 : "call create or loadExisting before usage!";
+        assert segments.length > 0 : "call create or loadExisting before usage!";
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         if (index + 4 > segmentSizeInBytes)
@@ -185,7 +177,7 @@ public class RAMDataAccess extends AbstractDataAccess {
 
     @Override
     public final void setShort(long bytePos, short value) {
-        assert segmentSizePower > 0 : "call create or loadExisting before usage!";
+        assert segments.length > 0 : "call create or loadExisting before usage!";
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         if (index + 2 > segmentSizeInBytes) {
@@ -199,7 +191,7 @@ public class RAMDataAccess extends AbstractDataAccess {
 
     @Override
     public final short getShort(long bytePos) {
-        assert segmentSizePower > 0 : "call create or loadExisting before usage!";
+        assert segments.length > 0 : "call create or loadExisting before usage!";
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         if (index + 2 > segmentSizeInBytes)
@@ -211,7 +203,7 @@ public class RAMDataAccess extends AbstractDataAccess {
     @Override
     public void setBytes(long bytePos, byte[] values, int length) {
         assert length <= segmentSizeInBytes : "the length has to be smaller or equal to the segment size: " + length + " vs. " + segmentSizeInBytes;
-        assert segmentSizePower > 0 : "call create or loadExisting before usage!";
+        assert segments.length > 0 : "call create or loadExisting before usage!";
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         byte[] seg = segments[bufferIndex];
@@ -229,7 +221,7 @@ public class RAMDataAccess extends AbstractDataAccess {
     @Override
     public void getBytes(long bytePos, byte[] values, int length) {
         assert length <= segmentSizeInBytes : "the length has to be smaller or equal to the segment size: " + length + " vs. " + segmentSizeInBytes;
-        assert segmentSizePower > 0 : "call create or loadExisting before usage!";
+        assert segments.length > 0 : "call create or loadExisting before usage!";
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         byte[] seg = segments[bufferIndex];
@@ -246,7 +238,7 @@ public class RAMDataAccess extends AbstractDataAccess {
 
     @Override
     public final void setByte(long bytePos, byte value) {
-        assert segmentSizePower > 0 : "call create or loadExisting before usage!";
+        assert segments.length > 0 : "call create or loadExisting before usage!";
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         segments[bufferIndex][index] = value;
@@ -254,7 +246,7 @@ public class RAMDataAccess extends AbstractDataAccess {
 
     @Override
     public final byte getByte(long bytePos) {
-        assert segmentSizePower > 0 : "call create or loadExisting before usage!";
+        assert segments.length > 0 : "call create or loadExisting before usage!";
         int bufferIndex = (int) (bytePos >>> segmentSizePower);
         int index = (int) (bytePos & indexDivisor);
         return segments[bufferIndex][index];

--- a/core/src/main/java/com/graphhopper/storage/StorableProperties.java
+++ b/core/src/main/java/com/graphhopper/storage/StorableProperties.java
@@ -41,9 +41,9 @@ public class StorableProperties {
     private final DataAccess da;
 
     public StorableProperties(Directory dir) {
-        this.da = dir.find("properties");
         // reduce size
-        da.setSegmentSize(1 << 15);
+        int segmentSize = 1 << 15;
+        this.da = dir.create("properties", segmentSize);
     }
 
     public synchronized boolean loadExisting() {
@@ -103,12 +103,11 @@ public class StorableProperties {
     public synchronized String get(String key) {
         if (!key.equals(toLowerCase(key)))
             throw new IllegalArgumentException("Do not use upper case keys (" + key + ") for StorableProperties since 0.7");
+        return map.getOrDefault(key, "");
+    }
 
-        String ret = map.get(key);
-        if (ret == null)
-            return "";
-
-        return ret;
+    public synchronized Map<String, String> getAll() {
+        return map;
     }
 
     public synchronized void close() {
@@ -177,6 +176,14 @@ public class StorableProperties {
                     + "See https://discuss.graphhopper.com/t/722");
         }
         return true;
+    }
+
+    public synchronized boolean containsVersion() {
+        return map.containsKey("nodes.version") ||
+               map.containsKey("edges.version") ||
+               map.containsKey("geometry.version") ||
+               map.containsKey("location_index.version") ||
+               map.containsKey("string_index.version");
     }
 
     @Override

--- a/core/src/main/java/com/graphhopper/storage/TurnCostStorage.java
+++ b/core/src/main/java/com/graphhopper/storage/TurnCostStorage.java
@@ -54,10 +54,6 @@ public class TurnCostStorage {
         this.turnCosts = turnCosts;
     }
 
-    public void setSegmentSize(int bytes) {
-        turnCosts.setSegmentSize(bytes);
-    }
-
     public TurnCostStorage create(long initBytes) {
         turnCosts.create(initBytes);
         return this;

--- a/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
+++ b/core/src/main/java/com/graphhopper/storage/index/LocationIndexTree.java
@@ -80,6 +80,18 @@ public class LocationIndexTree implements LocationIndex {
         this.graph = g;
         this.nodeAccess = g.getNodeAccess();
         this.directory = dir;
+
+        // Clone this defensively -- In case something funny happens and things get added to the Graph after
+        // this index is built. Reason is that the expected structure of the index is a function of the bbox, so we
+        // need it to be immutable.
+        BBox bounds = graph.getBounds().clone();
+
+        // I want to be able to create a location index for the empty graph without error, but for that
+        // I need valid bounds so that the initialization logic works.
+        if (!bounds.isValid())
+            bounds = new BBox(-10.0, 10.0, -10.0, 10.0);
+
+        lineIntIndex = new LineIntIndex(bounds, directory, "location_index");
     }
 
     public int getMinResolutionInMeter() {
@@ -120,18 +132,6 @@ public class LocationIndexTree implements LocationIndex {
     }
 
     public boolean loadExisting() {
-        // Clone this defensively -- In case something funny happens and things get added to the Graph after
-        // this index is built. Reason is that the expected structure of the index is a function of the bbox, so we
-        // need it to be immutable.
-        BBox bounds = graph.getBounds().clone();
-
-        // I want to be able to create a location index for the empty graph without error, but for that
-        // I need valid bounds so that the initialization logic works.
-        if (!bounds.isValid())
-            bounds = new BBox(-10.0,10.0,-10.0,10.0);
-
-        lineIntIndex = new LineIntIndex(bounds, directory, "location_index");
-
         if (!lineIntIndex.loadExisting())
             return false;
 
@@ -166,11 +166,10 @@ public class LocationIndexTree implements LocationIndex {
         // I want to be able to create a location index for the empty graph without error, but for that
         // I need valid bounds so that the initialization logic works.
         if (!bounds.isValid())
-            bounds = new BBox(-10.0,10.0,-10.0,10.0);
+            bounds = new BBox(-10.0, 10.0, -10.0, 10.0);
 
         InMemConstructionIndex inMemConstructionIndex = prepareInMemConstructionIndex(bounds, edgeFilter);
 
-        lineIntIndex = new LineIntIndex(bounds, directory, "location_index");
         lineIntIndex.setMinResolutionInMeter(minResolutionInMeter);
         lineIntIndex.store(inMemConstructionIndex);
         lineIntIndex.setChecksum(checksum());
@@ -309,6 +308,7 @@ public class LocationIndexTree implements LocationIndex {
         if (closestMatch.isValid()) {
             closestMatch.setQueryDistance(DIST_PLANE.calcDenormalizedDist(closestMatch.getQueryDistance()));
             closestMatch.calcSnappedPoint(DIST_PLANE);
+            closestMatch.setQueryDistance(DIST_PLANE.calcDist(closestMatch.getSnappedPoint().lat, closestMatch.getSnappedPoint().lon, queryLat, queryLon));
         }
         return closestMatch;
     }

--- a/core/src/main/java/com/graphhopper/util/GHUtility.java
+++ b/core/src/main/java/com/graphhopper/util/GHUtility.java
@@ -24,9 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graphhopper.coll.GHBitSet;
 import com.graphhopper.coll.GHBitSetImpl;
 import com.graphhopper.routing.ev.*;
-import com.graphhopper.routing.querygraph.EdgeIteratorStateHelper;
 import com.graphhopper.routing.util.*;
-import com.graphhopper.routing.weighting.QueryGraphWeighting;
 import com.graphhopper.routing.weighting.Weighting;
 import com.graphhopper.storage.*;
 import com.graphhopper.storage.index.LocationIndex;
@@ -514,6 +512,15 @@ public class GHUtility {
                 return origLast;
             }
         };
+    }
+
+    public static void checkDAVersion(String name, int expectedVersion, int version) {
+        if (version != expectedVersion) {
+            throw new IllegalStateException("Unexpected version for '" + name + "'. Got: " + version + ", " +
+                                            "expected: " + expectedVersion + ". "
+                                            + "Make sure you are using the same GraphHopper version for reading the files that was used for creating them. "
+                                            + "See https://discuss.graphhopper.com/t/722");
+        }
     }
 
     /**

--- a/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/CGIARProviderTest.java
@@ -91,7 +91,7 @@ public class CGIARProviderTest {
 
         // file not found => small!
         assertTrue(file.exists());
-        assertEquals(228, file.length());
+        assertEquals(1048676, file.length());
 
         instance.setDownloader(new Downloader("test GH") {
             @Override

--- a/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
+++ b/core/src/test/java/com/graphhopper/reader/dem/GMTEDProviderTest.java
@@ -98,7 +98,7 @@ public class GMTEDProviderTest {
 
         // file not found => small!
         assertTrue(file.exists());
-        assertEquals(228, file.length());
+        assertEquals(1048676, file.length());
 
         instance.setDownloader(new Downloader("test GH") {
             @Override

--- a/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
+++ b/core/src/test/java/com/graphhopper/routing/lm/LandmarkStorageTest.java
@@ -95,11 +95,10 @@ public class LandmarkStorageTest {
     public void testSetGetWeight() {
         GHUtility.setSpeed(60, true, true, encoder, graph.edge(0, 1).setDistance(40.1));
         Directory dir = new RAMDirectory();
-        DataAccess da = dir.find("landmarks_c1");
-        da.create(2000);
 
         LandmarkStorage lms = new LandmarkStorage(graph, dir, new LMConfig("c1", new FastestWeighting(encoder)), 4).
                 setMaximumWeight(LandmarkStorage.PRECISION);
+        lms._getInternalDA().create(2000);
         // 2^16=65536, use -1 for infinity and -2 for maximum
         lms.setWeight(0, 65536);
         // reached maximum value but do not reset to 0 instead use 2^16-2
@@ -108,14 +107,6 @@ public class LandmarkStorageTest {
         assertEquals(65534, lms.getFromWeight(0, 0));
         lms.setWeight(0, 79999);
         assertEquals(65534, lms.getFromWeight(0, 0));
-
-        da.setInt(0, Integer.MAX_VALUE);
-        assertTrue(lms.isInfinity(0));
-        // for infinity return much bigger value
-        // assertEquals(Integer.MAX_VALUE, lms.getFromWeight(0, 0));
-
-        lms.setWeight(0, 79999);
-        assertFalse(lms.isInfinity(0));
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/search/StringIndexTest.java
+++ b/core/src/test/java/com/graphhopper/search/StringIndexTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class StringIndexTest {
 
     private StringIndex create() {
-        return new StringIndex(new RAMDirectory()).create(1000);
+        return new StringIndex(new RAMDirectory(), 1000, -1).create(1000);
     }
 
     Map<String, String> createMap(String... strings) {
@@ -164,12 +164,12 @@ public class StringIndexTest {
         String location = "./target/stringindex-store";
         Helper.removeDir(new File(location));
 
-        StringIndex index = new StringIndex(new RAMDirectory(location, true).create()).create(1000);
+        StringIndex index = new StringIndex(new RAMDirectory(location, true).create(), 1000, -1).create(1000);
         long pointer = index.add(createMap("", "test"));
         index.flush();
         index.close();
 
-        index = new StringIndex(new RAMDirectory(location, true));
+        index = new StringIndex(new RAMDirectory(location, true), 1000, -1);
         assertTrue(index.loadExisting());
         assertEquals("test", index.get(pointer, ""));
         // make sure bytePointer is correctly set after loadExisting
@@ -185,7 +185,7 @@ public class StringIndexTest {
         String location = "./target/stringindex-store";
         Helper.removeDir(new File(location));
 
-        StringIndex index = new StringIndex(new RAMDirectory(location, true).create()).create(1000);
+        StringIndex index = new StringIndex(new RAMDirectory(location, true).create(), 1000, -1).create(1000);
         long pointerA = index.add(createMap("c", "test value"));
         assertEquals(2, index.getKeys().size());
         long pointerB = index.add(createMap("a", "value", "b", "another value"));
@@ -194,7 +194,7 @@ public class StringIndexTest {
         index.flush();
         index.close();
 
-        index = new StringIndex(new RAMDirectory(location, true));
+        index = new StringIndex(new RAMDirectory(location, true), 1000, -1);
         assertTrue(index.loadExisting());
         assertEquals("[, c, a, b]", index.getKeys().toString());
         assertEquals("test value", index.get(pointerA, "c"));

--- a/core/src/test/java/com/graphhopper/storage/AbstractDirectoryTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractDirectoryTester.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Peter Karich
@@ -50,11 +50,9 @@ public abstract class AbstractDirectoryTester {
     @Test
     public void testNoDuplicates() {
         Directory dir = createDir();
-        DataAccess da1 = dir.find("testing");
-        DataAccess da2 = dir.find("testing");
-        assertSame(da1, da2);
+        DataAccess da1 = dir.create("testing");
+        assertThrows(IllegalStateException.class, () -> dir.create("testing"));
         da1.close();
-        da2.close();
     }
 
     @Test

--- a/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
+++ b/core/src/test/java/com/graphhopper/storage/AbstractGraphStorageTester.java
@@ -658,7 +658,6 @@ public abstract class AbstractGraphStorageTester {
 
     @Test
     public void test8AndMoreBytesForEdgeFlags() {
-        Directory dir = new RAMDirectory();
         List<FlagEncoder> list = new ArrayList<>();
         list.add(new CarFlagEncoder(29, 0.001, 0) {
             @Override
@@ -668,7 +667,7 @@ public abstract class AbstractGraphStorageTester {
         });
         list.add(new CarFlagEncoder(29, 0.001, 0));
         EncodingManager manager = EncodingManager.create(list);
-        graph = new GraphHopperStorage(dir, manager, false).create(defaultSize);
+        graph = new GraphHopperStorage(new RAMDirectory(), manager, false).create(defaultSize);
 
         EdgeIteratorState edge = graph.edge(0, 1);
         IntsRef intsRef = manager.createEdgeFlags();
@@ -678,7 +677,7 @@ public abstract class AbstractGraphStorageTester {
         assertEquals(Integer.MAX_VALUE / 3, edge.getFlags().ints[0]);
         graph.close();
 
-        graph = new GraphHopperStorage(dir, manager, false).create(defaultSize);
+        graph = new GraphHopperStorage(new RAMDirectory(), manager, false).create(defaultSize);
 
         DecimalEncodedValue avSpeed0Enc = manager.getDecimalEncodedValue(getKey("car0", "average_speed"));
         BooleanEncodedValue access0Enc = manager.getBooleanEncodedValue(getKey("car0", "access"));

--- a/core/src/test/java/com/graphhopper/storage/MMapDataAccessTest.java
+++ b/core/src/test/java/com/graphhopper/storage/MMapDataAccessTest.java
@@ -26,13 +26,13 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class MMapDataAccessTest extends DataAccessTest {
     @Override
-    public DataAccess createDataAccess(String name) {
-        return new MMapDataAccess(name, directory, defaultOrder, true).setSegmentSize(128);
+    public DataAccess createDataAccess(String name, int segmentSize) {
+        return new MMapDataAccess(name, directory, true, segmentSize);
     }
 
     @Test
     public void textMixRAM2MMAP() {
-        DataAccess da = new RAMDataAccess(name, directory, true, defaultOrder);
+        DataAccess da = new RAMDataAccess(name, directory, true, -1);
         assertFalse(da.loadExisting());
         da.create(100);
         da.setInt(7 * 4, 123);
@@ -54,7 +54,7 @@ public class MMapDataAccessTest extends DataAccessTest {
         // TODO "memory mapped flush" is expensive and not required. only writing the header is required.
         da.flush();
         da.close();
-        da = new RAMDataAccess(name, directory, true, defaultOrder);
+        da = new RAMDataAccess(name, directory, true, -1);
         assertTrue(da.loadExisting());
         assertEquals(123, da.getInt(7 * 4));
         da.close();

--- a/core/src/test/java/com/graphhopper/storage/RAMDataAccessTest.java
+++ b/core/src/test/java/com/graphhopper/storage/RAMDataAccessTest.java
@@ -22,7 +22,7 @@ package com.graphhopper.storage;
  */
 public class RAMDataAccessTest extends DataAccessTest {
     @Override
-    public DataAccess createDataAccess(String name) {
-        return new RAMDataAccess(name, directory, true, defaultOrder).setSegmentSize(128);
+    public DataAccess createDataAccess(String name, int segmentSize) {
+        return new RAMDataAccess(name, directory, true, segmentSize);
     }
 }

--- a/core/src/test/java/com/graphhopper/storage/RAMIntDataAccessTest.java
+++ b/core/src/test/java/com/graphhopper/storage/RAMIntDataAccessTest.java
@@ -22,8 +22,8 @@ package com.graphhopper.storage;
  */
 public class RAMIntDataAccessTest extends DataAccessTest {
     @Override
-    public DataAccess createDataAccess(String name) {
-        return new RAMIntDataAccess(name, directory, true, defaultOrder).setSegmentSize(128);
+    public DataAccess createDataAccess(String name, int segmentSize) {
+        return new RAMIntDataAccess(name, directory, true, segmentSize);
     }
 
     @Override


### PR DESCRIPTION
This PR 
- bumps up the java version to 17
- updates around DataAccess to newer Graphhopper GH5+ version.

Compatibilities

* with 5.x - master 
  - AbstractDataAccess / DataAccess
  - Directory / GHDirectory
  - MMapDataAccess, RAMDataAccess, RAMIntDataAccess
  - StorableProperties

other file are updated to reflect changes in DataAccess but not fully updated to gh 5.x or higher versions.
Most of this changes are cause that DataAccess don't support `setSegmentSize` anymore! `SegmentSize` is now passed to the constructor.


> Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

> Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
