### PR TITLE
fix: Replace java compile target with the default defined version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -182,14 +182,6 @@
                     <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                </configuration>
-            </plugin>
         </plugins>
 
         <!-- make version available at runtime via version file -->

--- a/hmm-lib/pom.xml
+++ b/hmm-lib/pom.xml
@@ -57,17 +57,4 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
Currently, the hmm-lib module is still build in compatibility mode. Let's fix this.

Please read [our contributing guide](https://github.com/graphhopper/graphhopper/blob/master/CONTRIBUTING.md) and note that also your contribution falls under the Apache License 2.0 as outlined there.

Your first contribution should include a change where you add yourself to the CONTRIBUTORS.md file.
