### PR TITLE
fix: passing of time to routing algorithms

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -405,8 +405,7 @@ public class Router {
 
     // ORS GH-MOD START
     private static long getTime(PMap hints) {
-        Instant time = hints.has("departure") ? hints.getObject("departure", null) : hints.getObject("arrival", null);
-        return (time == null) ? -1 : time.toEpochMilli();
+        return hints.getLong("time", -1);
     }
 
     // way to inject additional edgeFilters to router


### PR DESCRIPTION
Use a common time parameter which is set upstream only when the algorithm actually requires it.

Required by https://github.com/GIScience/openrouteservice/pull/1871.

