### PR TITLE
fix: update protobuf-java

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.22.3</version>
+            <version>3.25.5</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
currently used version of protobuf-java has vulnerability CWE-121 / CVE-2024-7254 / CVSS 8.7
