### PR TITLE
fix: pass extra_info when quering round_trip

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/Router.java
+++ b/core/src/main/java/com/graphhopper/routing/Router.java
@@ -219,8 +219,15 @@ public class Router {
         RoundTripRouting.Result result = RoundTripRouting.calcPaths(snaps, pathCalculator);
         // we merge the different legs of the roundtrip into one response path
         ResponsePath responsePath = concatenatePaths(request, solver.weighting, queryGraph, result.paths, getWaypoints(snaps));
-        ghRsp.add(responsePath);
+
         // ORS-GH MOD START - pass graph date
+        if (request.getEncoderName() != null && !request.getEncoderName().isEmpty()) {
+            PathProcessor pathProcessor = pathProcessorFactory.createPathProcessor(request.getAdditionalHints(), encodingManager.getEncoder(request.getEncoderName()), ghStorage);
+            responsePath = concatenatePaths(request, solver.weighting, queryGraph, result.paths, getWaypoints(snaps), pathProcessor);
+            ghRsp.addReturnObject(pathProcessor);
+        }
+        ghRsp.add(responsePath);
+
         String date = ghStorage.getProperties().get("datareader.import.date");
         if (Helper.isEmpty(date)) {
             date = ghStorage.getProperties().get("datareader.data.date");


### PR DESCRIPTION
Part of fix for https://github.com/GIScience/openrouteservice/issues/1976

The `PathProcessor` class responsible for setting up the `extra_infos` processing was only applied in `routeVia` and `routeAlt` methods but not in `routeRoundTrip` which lead to no `extra_infos` to be returned on round trips.