### PR TITLE
refactor: store OSM node IDs only for tower nodes using a compact array

### DIFF
--- a/client-hc/pom.xml
+++ b/client-hc/pom.xml
@@ -22,21 +22,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>directions-api-client-hc</artifactId>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>GraphHopper Directions API hand-crafted Java Client.</name>
      
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>  
     
     <dependencies>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-api</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>graphhopper-core</artifactId>
     <name>GraphHopper Core</name>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>
         GraphHopper is a fast and memory efficient Java road routing engine
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-api</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.carrotsearch</groupId>

--- a/core/src/main/java/com/graphhopper/reader/osm/OSMNodeData.java
+++ b/core/src/main/java/com/graphhopper/reader/osm/OSMNodeData.java
@@ -19,8 +19,9 @@
 package com.graphhopper.reader.osm;
 
 // ORS-GH MOD START
-import com.carrotsearch.hppc.IntLongMap;
-import com.graphhopper.coll.GHIntLongHashMap;
+import com.carrotsearch.hppc.LongArrayList;
+import com.carrotsearch.hppc.LongLongMap;
+import com.graphhopper.coll.GHLongLongHashMap;
 // ORS-GH MOD END
 import com.graphhopper.coll.GHLongIntBTree;
 import com.graphhopper.coll.LongIntMap;
@@ -69,7 +70,8 @@ public class OSMNodeData {
     // this map stores our internal node id for each OSM node
     private final LongIntMap idsByOsmNodeIds;
     // ORS-GH MOD START - mapping in the other direction: internal node IDs to OSM node IDs
-    private final IntLongMap osmNodeIdsByIds;
+    private final LongArrayList osmNodeIdsByIds;
+    private final LongLongMap originalOsmNodeIds;
     // ORS-GH MOD END
 
     // here we store node coordinates, separated for pillar and tower nodes
@@ -94,7 +96,8 @@ public class OSMNodeData {
         // entries.
         idsByOsmNodeIds = new GHLongIntBTree(200);
         // ORS-GH MOD START
-        osmNodeIdsByIds = new GHIntLongHashMap(200);
+        osmNodeIdsByIds = new LongArrayList(200);
+        originalOsmNodeIds = new GHLongLongHashMap(200);
         // ORS-GH MOD END
         towerNodes = nodeAccess;
         pillarNodes = new PillarInfo(towerNodes.is3D(), directory);
@@ -175,7 +178,7 @@ public class OSMNodeData {
         int id = towerNodeToId(nextTowerId);
         idsByOsmNodeIds.put(osmId, id);
         // ORS-GH MOD START
-        addOsmNodeIdById(id, osmId);
+        addOsmNodeIdById(nextTowerId, osmId);
         // ORS-GH MOD END
         nextTowerId++;
         return id;
@@ -185,9 +188,6 @@ public class OSMNodeData {
         pillarNodes.setNode(nextPillarId, lat, lon, ele);
         int id = pillarNodeToId(nextPillarId);
         idsByOsmNodeIds.put(osmId, id);
-        // ORS-GH MOD START
-        addOsmNodeIdById(id, osmId);
-        // ORS-GH MOD END
         nextPillarId++;
         return id;
     }
@@ -202,12 +202,12 @@ public class OSMNodeData {
         if (point == null)
             throw new IllegalStateException("Cannot copy node : " + node.osmNodeId + ", because it is missing");
         final long newOsmId = nextArtificialOSMNodeId++;
+        // ORS-GH MOD START
+        originalOsmNodeIds.put(newOsmId, node.osmNodeId);
+        // ORS-GH MOD END
         if (idsByOsmNodeIds.put(newOsmId, INTERMEDIATE_NODE) != EMPTY_NODE)
             throw new IllegalStateException("Artificial osm node id already exists: " + newOsmId);
         int id = addPillarNode(newOsmId, point.getLat(), point.getLon(), point.getEle());
-        // ORS-GH MOD START
-        addOsmNodeIdById(id, node.osmNodeId);
-        // ORS-GH MOD END
         return new SegmentNode(newOsmId, id);
     }
 
@@ -222,12 +222,7 @@ public class OSMNodeData {
             throw new IllegalStateException("Pillar node was already converted to tower node: " + id);
 
         pillarNodes.setNode(pillar, Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-        // ORS-GH MOD START
-        int newId = addTowerNode(osmNodeId, lat, lon, ele);
-        if (osmNodeId < 0)
-            osmNodeIdsByIds.put(newId, getOsmId(id));
-        return newId;
-        // ORS-GH MOD END
+        return addTowerNode(osmNodeId, lat, lon, ele);
     }
 
     public GHPoint3D getCoordinates(int id) {
@@ -310,15 +305,15 @@ public class OSMNodeData {
     }
 
     // ORS-GH MOD START - additional methods
-    private void addOsmNodeIdById(int id, long osmId) {
+    private void addOsmNodeIdById(int towerId, long osmId) {
         if (osmId < 0) {
-            return;// skip artificial OSM node IDs, because they are not part of the original OSM data
+            osmId = originalOsmNodeIds.get(osmId);
         }
-        osmNodeIdsByIds.put(id, osmId);
+        osmNodeIdsByIds.insert(towerId, osmId);
     }
 
-    public long getOsmId(int id) {
-        return osmNodeIdsByIds.get(id);
+    public long getOsmId(int towerId) {
+        return osmNodeIdsByIds.get(towerId);
     }
     // ORS-GH MOD END
 }

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -5,21 +5,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>graphhopper-example</artifactId>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>GraphHopper Example</name>
 
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>  
 
     <dependencies>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
 
         <!-- you can use this for logging or any slf4j log implementation -->

--- a/hmm-lib/pom.xml
+++ b/hmm-lib/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>hmm-lib-external</artifactId>
     <!-- SNAPSHOT is necessary otherwise it says: Deployment failed: repository element was not specified in the POM inside distributionManagement element-->
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <packaging>jar</packaging>
   
     <name>hmm-lib</name>
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>
 
     <developers>

--- a/map-matching/pom.xml
+++ b/map-matching/pom.xml
@@ -3,21 +3,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>graphhopper-map-matching</artifactId>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>GraphHopper Map Matching</name>
 
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>
     
     <dependencies>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>hmm-lib-external</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/navigation/pom.xml
+++ b/navigation/pom.xml
@@ -5,26 +5,26 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>graphhopper-nav</artifactId>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>GraphHopper Navigation</name>
 
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>  
 
     <dependencies>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-api</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.GIScience.graphhopper</groupId>
     <artifactId>graphhopper-parent</artifactId>
-    <name>GraphHopper Parent Project</name><version>4.13-SNAPSHOT</version>
+    <name>GraphHopper Parent Project</name><version>4.15-SNAPSHOT</version>
     <packaging>pom</packaging>
     <url>https://www.graphhopper.com</url>
     <inceptionYear>2012</inceptionYear>

--- a/reader-gtfs/pom.xml
+++ b/reader-gtfs/pom.xml
@@ -10,14 +10,14 @@
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>
     <properties>
         <assembly-phase>package</assembly-phase>
@@ -20,12 +20,12 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-api</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/web-api/pom.xml
+++ b/web-api/pom.xml
@@ -5,14 +5,14 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>graphhopper-web-api</artifactId>
     <packaging>jar</packaging>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <name>GraphHopper Web API</name>
     <description>JSON Representation of the API classes</description>
 
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -5,36 +5,36 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>graphhopper-web-bundle</artifactId>
     <packaging>jar</packaging>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <name>GraphHopper Dropwizard Bundle</name>
     <description>Use the GraphHopper routing engine as a web-service</description>
 
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-api</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-core</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-reader-gtfs</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-map-matching</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
 
         <!-- required for JDK9 -->
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>directions-api-client-hc</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,14 +5,14 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>graphhopper-web</artifactId>
     <packaging>jar</packaging>
-    <version>4.13-SNAPSHOT</version>
+    <version>4.15-SNAPSHOT</version>
     <name>GraphHopper Web</name>
     <description>Use the GraphHopper routing engine as a web-service</description>
 
     <parent>
         <groupId>com.github.GIScience.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>4.13-SNAPSHOT</version>
+        <version>4.15-SNAPSHOT</version>
     </parent>
     <properties>
         <shade-phase>package</shade-phase>
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-web-bundle</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>graphhopper-nav</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.github.GIScience.graphhopper</groupId>
             <artifactId>directions-api-client-hc</artifactId>
-            <version>4.13-SNAPSHOT</version>
+            <version>4.15-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
The previous `<Integer, Long>` hash map approach was unscalable for larger datasets like the full planet file. This optimization reduces memory usage via two key insights:
1. It is not necessary to store the mapping for pillar nodes.
2. Tower node IDs are sequentially assigned from zero, allowing them to serve as direct indices into a primitive `long[]` array of OSM IDs. 

A smaller `<Long, Long>` auxiliary hash map handles the mapping of artificial OSM IDs back to their original counterparts.